### PR TITLE
only deploy db subnet if mlflow tracking enabled

### DIFF
--- a/infra/base/terraform/variables.tf
+++ b/infra/base/terraform/variables.tf
@@ -27,8 +27,8 @@ variable "vpc_cidr" {
 # Note you can only /16 range to VPC. You can add multiples of /16 if required
 variable "secondary_cidr_blocks" {
   description = "Secondary CIDR blocks to be attached to VPC"
-  default = ["100.64.0.0/16"]
-  type = list(string)
+  default     = ["100.64.0.0/16"]
+  type        = list(string)
 }
 
 variable "enable_database_subnets" {

--- a/infra/base/terraform/variables.tf
+++ b/infra/base/terraform/variables.tf
@@ -27,8 +27,14 @@ variable "vpc_cidr" {
 # Note you can only /16 range to VPC. You can add multiples of /16 if required
 variable "secondary_cidr_blocks" {
   description = "Secondary CIDR blocks to be attached to VPC"
-  default     = ["100.64.0.0/16"]
-  type        = list(string)
+  default = ["100.64.0.0/16"]
+  type = list(string)
+}
+
+variable "enable_database_subnets" {
+  description = "Whether or not to enable the database subnets"
+  type        = bool
+  default     = false
 }
 
 # Infrastructure Variables

--- a/infra/base/terraform/vpc.tf
+++ b/infra/base/terraform/vpc.tf
@@ -37,8 +37,8 @@ module "vpc" {
   # ------------------------------
   # Private Subnets for MLflow backend store
   database_subnets                   = local.database_private_subnets
-  create_database_subnet_group       = true
-  create_database_subnet_route_table = true
+  create_database_subnet_group       = var.enable_mlflow_tracking
+  create_database_subnet_route_table = var.enable_mlflow_tracking
 
   # ------------------------------
   # Optional Public Subnets for NAT and IGW for PoC/Dev/Test environments

--- a/infra/base/terraform/vpc.tf
+++ b/infra/base/terraform/vpc.tf
@@ -37,8 +37,8 @@ module "vpc" {
   # ------------------------------
   # Private Subnets for MLflow backend store
   database_subnets                   = local.database_private_subnets
-  create_database_subnet_group       = var.enable_mlflow_tracking
-  create_database_subnet_route_table = var.enable_mlflow_tracking
+  create_database_subnet_group       = var.enable_database_subnets
+  create_database_subnet_route_table = var.enable_database_subnets
 
   # ------------------------------
   # Optional Public Subnets for NAT and IGW for PoC/Dev/Test environments

--- a/infra/mlflow/terraform/blueprint.tfvars
+++ b/infra/mlflow/terraform/blueprint.tfvars
@@ -2,3 +2,4 @@ name                          = "mlflow-on-eks"
 enable_aws_cloudwatch_metrics = true
 enable_amazon_prometheus      = true
 enable_mlflow_tracking        = true
+enable_database_subnets       = true


### PR DESCRIPTION
### What does this PR do?

Fixes creating db subnets/routetables regardless of whether or not they're needed.

