### PR TITLE
update data addons

### DIFF
--- a/infra/base/terraform/addons.tf
+++ b/infra/base/terraform/addons.tf
@@ -207,7 +207,7 @@ module "eks_blueprints_addons" {
 
 module "data_addons" {
   source  = "aws-ia/eks-data-addons/aws"
-  version = "1.36.0"
+  version = "1.37.0"
 
   oidc_provider_arn = module.eks.oidc_provider_arn
 
@@ -330,7 +330,6 @@ module "data_addons" {
   enable_aws_neuron_device_plugin = true
 
   aws_neuron_device_plugin_helm_config = {
-    version = 1.1.1
     # Enable default scheduler
     values = [
       <<-EOT


### PR DESCRIPTION
### What does this PR do?

Updates the data_addons terraform module to pull the neuron chart directly rather than having it specified

### Motivation

Stay consistent with upstream addons

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
