### PR TITLE
add tufflehog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,6 @@ repos:
       - id: trufflehog
         name: TruffleHog
         description: Detect secrets in your data.
-        entry: bash -c 'trufflehog git file://. --since-commit main --fail '
+        entry: bash -c 'trufflehog git file://. --since-commit main --fail --no-update'
         language: system
-        stages: ["commit", "push"]
+        stages: ["pre-commit", "pre-push"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,6 @@ repos:
       - id: trufflehog
         name: TruffleHog
         description: Detect secrets in your data.
-        entry: bash -c 'trufflehog git file://. --since-commit main --fail --no-update'
+        entry: bash -c 'trufflehog git file://. --since-commit HEAD --fail --no-update'
         language: system
         stages: ["pre-commit", "pre-push"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,11 @@ repos:
           - --args=--only=terraform_workspace_remote
       - id: terraform_validate
         exclude: (docs|modules)
+  - repo: local
+    hooks:
+      - id: trufflehog
+        name: TruffleHog
+        description: Detect secrets in your data.
+        entry: bash -c 'trufflehog git file://. --since-commit main --fail '
+        language: system
+        stages: ["commit", "push"]


### PR DESCRIPTION
### What does this PR do?

Enables trufflehog for secret scanning in pre-commits

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
