### PR TITLE
Switch neuron amis to bottlerocket

### DIFF
--- a/infra/base/terraform/addons.tf
+++ b/infra/base/terraform/addons.tf
@@ -128,7 +128,7 @@ module "eks_blueprints_addons" {
     }
   }
   karpenter = {
-    chart_version       = "1.3.3"
+    chart_version       = "1.4.0"
     repository_username = data.aws_ecrpublic_authorization_token.token.user_name
     repository_password = data.aws_ecrpublic_authorization_token.token.password
     source_policy_documents = [

--- a/infra/base/terraform/addons.tf
+++ b/infra/base/terraform/addons.tf
@@ -600,7 +600,7 @@ module "data_addons" {
         securityGroupSelectorTerms:
           tags:
             Name: ${module.eks.cluster_name}-node
-        blockDevice:
+        blockDeviceMappings:
           # Root device
           - deviceName: /dev/xvda
             ebs:

--- a/infra/base/terraform/addons.tf
+++ b/infra/base/terraform/addons.tf
@@ -128,7 +128,7 @@ module "eks_blueprints_addons" {
     }
   }
   karpenter = {
-    chart_version       = "1.2.1"
+    chart_version       = "1.3.3"
     repository_username = data.aws_ecrpublic_authorization_token.token.user_name
     repository_password = data.aws_ecrpublic_authorization_token.token.password
     source_policy_documents = [
@@ -534,7 +534,7 @@ module "data_addons" {
       clusterName: ${module.eks.cluster_name}
       ec2NodeClass:
         amiSelectorTerms:
-          - alias: al2023@latest
+          - alias: bottlerocket@latest
         karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
         subnetSelectorTerms:
           id: ${module.vpc.private_subnets[2]}
@@ -593,7 +593,7 @@ module "data_addons" {
       clusterName: ${module.eks.cluster_name}
       ec2NodeClass:
         amiSelectorTerms:
-          - alias: al2023@latest
+          - alias: bottlerocket@latest
         karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
         subnetSelectorTerms:
           id: ${module.vpc.private_subnets[2]}


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/ai-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

This PR updates Karpenter to v1.4.0 to support using bottlerocket AMIs with neuron nodes. 

### Motivation
Fixes #58 
Bottlerocket is a more secure AMI. Also inf2 nodes were not properly set up for ephemeral storage

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
![image](https://github.com/user-attachments/assets/dad51465-d51f-455a-9abb-379a824944e1)
![image](https://github.com/user-attachments/assets/37cffeb1-687c-4741-985e-b984de19d2c1)
