### PR TITLE
feat: Enable ai-ml-observability-stack

### DIFF
--- a/infra/base/terraform/argocd-addons/ai-ml-observability.yaml
+++ b/infra/base/terraform/argocd-addons/ai-ml-observability.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ai-ml-obs-ref-arch
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/awslabs/ai-ml-observability-reference-architecture.git
+    targetRevision: HEAD
+    path: deploy
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    syncOptions:
+      - ServerSideApply=true
+    automated: {}

--- a/infra/base/terraform/argocd_addons.tf
+++ b/infra/base/terraform/argocd_addons.tf
@@ -1,0 +1,4 @@
+resource "kubectl_manifest" "ai_ml_observability_yaml" {
+  count     = var.enable_ai_ml_observability_stack ? 1 : 0
+  yaml_body = file("${path.module}/argocd-addons/ai-ml-observability.yaml")
+}

--- a/infra/base/terraform/variables.tf
+++ b/infra/base/terraform/variables.tf
@@ -89,6 +89,11 @@ variable "enable_kubecost" {
   type        = bool
   default     = false
 }
+variable "enable_ai_ml_observability_stack" {
+  description = "Enable AI/ML observability addon"
+  type        = bool
+  default     = false
+}
 variable "enable_argo_workflows" {
   description = "Enable Argo Workflows addon"
   type        = bool

--- a/infra/jark-stack/terraform/blueprint.tfvars
+++ b/infra/jark-stack/terraform/blueprint.tfvars
@@ -1,7 +1,9 @@
-name                          = "jark-stack"
-enable_aws_efs_csi_driver     = true
-enable_aws_cloudwatch_metrics = true
-enable_jupyterhub             = true
-enable_kuberay_operator       = true
-enable_argo_workflows         = true
-enable_argo_events            = true
+name                             = "jark-stack"
+enable_aws_efs_csi_driver        = true
+enable_aws_cloudwatch_metrics    = true
+enable_jupyterhub                = true
+enable_kuberay_operator          = true
+enable_argo_workflows            = true
+enable_argo_events               = true
+enable_argocd                    = true
+enable_ai_ml_observability_stack = true

--- a/website/docs/bestpractices/observability.md
+++ b/website/docs/bestpractices/observability.md
@@ -1,0 +1,127 @@
+# Observability
+
+Observability for AI/ML workloads requires a holistic view of multiple hardware/software components alongside multiple sources of data such as logs, metrics, and traces. Piecing together these components is challenging and time-consuming; therefore, we leverage the [AI/ML Observability](https://github.com/awslabs/ai-ml-observability-reference-architecture) available in Github to bootstrap this environment.
+
+## Architecture
+![Architecture](https://github.com/awslabs/ai-ml-observability-reference-architecture/raw/main/static/reference_architecture.png)
+
+## What's Included
+- Prometheus
+- OpenSearch
+- FluentBit
+- Kube State Metrics
+- Metrics Server
+- Alertmanager
+- Grafana
+- Pod/Service monitors for AI/ML workloads
+- AI/ML Dashboards
+
+## Why
+Understanding the performance of AI/ML workloads is challenging: Is the GPU getting data fast enough? Is the CPU the bottleneck? Is the storage fast enough? These are questions that are hard to answer in isolation. The more of the picture one is able to see, the more clarity there is in identifying performance bottlenecks.
+
+## How
+The [JARK](https://awslabs.github.io/ai-on-eks/docs/infra/ai-ml/jark) infrastructure already comes with this architecture enabled by default, if you would like to add it to your infrastructure, you need to ensure 2 variables are set to `true` in `blueprint.tfvars`:
+
+```yaml
+enable_argocd                    = true
+enable_ai_ml_observability_stack = true
+```
+
+The first variable deploys ArgoCD, which is used to deploy the observability architecture, the second variable deploys the architecture.
+
+## Usage
+The architecture is entirely deployed into the `monitoring` namespace. To access Grafana: `kubectl port-forward -n monitoring svc/kube-prometheus-stack-grafana 3000:80`. You can then open https://localhost:3000 to log into grafana with username `admin` and password `prom-operator`. You can refer to the [security](https://github.com/awslabs/ai-ml-observability-reference-architecture?tab=readme-ov-file#security) section in the Readme to see how to change the username/password
+
+### Training
+Ray training job logs and metrics will be automatically collected by the Observability architecture and can be found in the [training dashboard] (http://localhost:3000/d/ee6mbjghme96oc/gpu-training?orgId=1&refresh=5s&var-namespace=default&var-job=ray-train&var-instance=All).
+
+#### Example
+A full example of this can be found in the [AI/ML observability repo](https://github.com/awslabs/ai-ml-observability-reference-architecture/tree/main/examples/training). We will also be updating the Blueprints here to make use of this architecture.
+
+### Inference
+Ray inference metrics should be automatically picked up by the observability infrastructure and can be found in the [inference dashboard] (http://localhost:3000/d/bec31e71-3ac5-4133-b2e3-b9f75c8ab56c/inference-dashboard?orgId=1&refresh=5s). To instrument your inference workloads for logging, you will need to add a few items:
+
+#### FluentBit Config
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentbit-config
+  namespace: default
+data:
+  fluent-bit.conf: |-
+    [INPUT]
+        Name tail
+        Path /tmp/ray/session_latest/logs/*
+        Tag ray
+        Path_Key true
+        Refresh_Interval 5
+    [FILTER]
+        Name modify
+        Match ray
+        Add POD_LABELS ${POD_LABELS}
+    [OUTPUT]
+        Name stdout
+        Format json
+```
+Deploy this into the namespace in which you intend to run your inference workload. You only need one in each namespace to tell the FluentBit sidecar how to output the logs.
+
+#### FluentBit Sidecar
+We will need to add a sidecar to the Ray inference service so FluentBit can write the logs to STDOUT
+```yaml
+              - name: fluentbit
+                image: fluent/fluent-bit:3.2.2
+                env:
+                  - name: POD_LABELS
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.labels['ray.io/cluster']
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 128Mi
+                  limits:
+                    cpu: 100m
+                    memory: 128Mi
+                volumeMounts:
+                  - mountPath: /tmp/ray
+                    name: ray-logs
+                  - mountPath: /fluent-bit/etc/fluent-bit.conf
+                    subPath: fluent-bit.conf
+                    name: fluentbit-config
+```
+Add this section to the `workerGroupSpecs` containers
+
+#### FluentBit Volume
+Finally, we need to add the configmap volume to our `volumes` section:
+```yaml
+              - name: fluentbit-config
+                configMap:
+                  name: fluentbit-config
+```
+
+#### vLLM Metrics
+vLLM also outputs useful metrics like the Time to First Token, throughput, latencies, cache utilization and more. To get access to these metrics, we need to add a route to our pod for the metrics path:
+
+```python
+# Imports
+import re
+from prometheus_client import make_asgi_app
+from fastapi import FastAPI
+from starlette.routing import Mount
+
+app = FastAPI()
+
+class Deployment:
+    def _init__(selfself, **kwargs):
+        ...
+        route = Mount("/metrics", make_asgi_app())
+        # Workaround for 307 Redirect for /metrics
+        route.path_regex = re.compile('^/metrics(?P<path>.*)$')
+        app.routes.append(route)
+```
+
+This will allow the deployed monitor to collect the vLLM metrics and display them in the inference dashboard.
+
+#### Example
+A full example of this can be found in the [AI/ML observability repo](https://github.com/awslabs/ai-ml-observability-reference-architecture/tree/main/examples/inference). We will also be updating the Blueprints here to make use of this architecture.

--- a/website/docs/infra/ai-ml/jark.md
+++ b/website/docs/infra/ai-ml/jark.md
@@ -17,6 +17,8 @@ These instructions only deploy the JARK cluster as a base. If you are looking to
 ### What is JARK?
 JARK is a powerful stack composed of [JupyterHub](https://jupyter.org/hub), [Argo Workflows](https://github.com/argoproj/argo-workflows), [Ray](https://github.com/ray-project/ray), and [Kubernetes](https://kubernetes.io/), designed to streamline the deployment and management of Generative AI models on Amazon EKS. This stack brings together some of the most effective tools in the AI and Kubernetes ecosystem, offering a robust solution for training, fine-tuning, and inference large AI models.
 
+JARK comes enabled with [AI/ML Observability](https://github.com/awslabs/ai-ml-observability-reference-architecture). Please see the [observability](https://awslabs.github.io/ai-on-eks/docs/bestpractices/observability) section for details on the observability architecture.
+
 ### Key Features and Benefits
 [JupyterHub](https://jupyter.org/hub): Provides a collaborative environment for running notebooks, crucial for model development and prompt engineering.
 


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/ai-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

Fixes #21 
This PR adds the awslabs/ai-ml-observability-reference-architecture as an addon and enables it for the JARK stack, giving an out of the box observability solution. 

### Motivation

AI/ML observability is needed for an AI platform. This architecture sets up all the components needed for monitoring the environment and workloads running in it. 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
![image](https://github.com/user-attachments/assets/df6fac7f-05ed-4113-b82b-fd5bc8302f07)
