### PR TITLE
fix: Use annotation tracking for argocd resources

### DIFF
--- a/infra/base/terraform/helm-values/argocd-values.yaml
+++ b/infra/base/terraform/helm-values/argocd-values.yaml
@@ -2,3 +2,4 @@
 configs:
   cm:
     kustomize.buildOptions: --enable-helm
+    application.resourceTrackingMethod: annotation


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/ai-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

This PR moves resource tracking for ArgoCD from labels to annotations

### Motivation

ArgoCD uses labels to track resources by default, which end up with ArgoCD overwriting the proper label on the resource with the app deployment name. This causes issues with prometheus service/pod monitor identifying the proper resources to scrape. 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
