### PR TITLE
feat: Extract efs module, move NIM to argocd addon

### DIFF
--- a/infra/base/terraform/argocd-addons/nvidia-nim-operator.yaml
+++ b/infra/base/terraform/argocd-addons/nvidia-nim-operator.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nim-operator
+  namespace: argocd
+spec:
+  project: default
+  source:
+    chart: k8s-nim-operator
+    repoURL: https://helm.ngc.nvidia.com/nvidia
+    targetRevision: "v1.0.1"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: nim-operator
+  syncPolicy:
+    syncOptions:
+      - ServerSideApply=true
+      - CreateNamespace=true
+    automated: {}

--- a/infra/base/terraform/argocd_addons.tf
+++ b/infra/base/terraform/argocd_addons.tf
@@ -2,3 +2,8 @@ resource "kubectl_manifest" "ai_ml_observability_yaml" {
   count     = var.enable_ai_ml_observability_stack ? 1 : 0
   yaml_body = file("${path.module}/argocd-addons/ai-ml-observability.yaml")
 }
+
+resource "kubectl_manifest" "nvidia_nim_yaml" {
+  count     = var.enable_nvidia_nim_stack ? 1 : 0
+  yaml_body = file("${path.module}/argocd-addons/nvidia-nim-operator.yaml")
+}

--- a/infra/base/terraform/efs.tf
+++ b/infra/base/terraform/efs.tf
@@ -2,10 +2,7 @@
 # AWS EFS Module: Shared Persistent Storage for Model Caching
 #
 # This module provisions an Amazon EFS (Elastic File System)
-# with mount targets across availability zones. It is used as
-# ReadWriteMany shared storage for NIMCache, allowing cached
-# models to persist across pod restarts and be reused by multiple
-# NIMService pods for faster startup and reduced cold boot latency.
+# with mount targets across availability zones.
 #---------------------------------------------------------------
 module "efs" {
   count   = var.enable_aws_efs_csi_driver ? 1 : 0
@@ -37,8 +34,7 @@ module "efs" {
 #
 # This StorageClass enables dynamic provisioning of EFS volumes
 # using the AWS EFS CSI driver. It is used by NIMCache CRD to create
-# a PersistentVolumeClaim (PVC) with ReadWriteMany access mode,
-# essential for sharing cached models between GPU pods in NIMService.
+# a PersistentVolumeClaim (PVC) with ReadWriteMany access mode.
 #---------------------------------------------------------------
 resource "kubernetes_storage_class_v1" "efs" {
   metadata {

--- a/infra/base/terraform/variables.tf
+++ b/infra/base/terraform/variables.tf
@@ -153,6 +153,13 @@ variable "enable_mpi_operator" {
   default     = false
 }
 
+# ArgoCD Addons
+variable "enable_nvidia_nim_stack" {
+  description = "Flag to enable the NVIDIA NIM Stack addon"
+  type        = bool
+  default     = false
+}
+
 # Jupyterhub Specific Variables
 
 # NOTE: You need to use private domain or public domain name with ACM certificate

--- a/infra/nvidia-nim/terraform/blueprint.tfvars
+++ b/infra/nvidia-nim/terraform/blueprint.tfvars
@@ -1,6 +1,5 @@
-
-# Infra base stack variables "infra/base/terraform/variables.tf
 name                          = "nvidia-nim-eks"
 region                        = "us-west-2"
 enable_aws_cloudwatch_metrics = true
 enable_aws_efs_csi_driver     = true
+enable_nvidia_nim_stack       = true

--- a/infra/nvidia-nim/terraform/blueprint.tfvars
+++ b/infra/nvidia-nim/terraform/blueprint.tfvars
@@ -2,4 +2,5 @@ name                          = "nvidia-nim-eks"
 region                        = "us-west-2"
 enable_aws_cloudwatch_metrics = true
 enable_aws_efs_csi_driver     = true
+enable_argocd                 = true
 enable_nvidia_nim_stack       = true


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/ai-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

Fixes #64 
This module extracts the EFS configuration out of the jupyter terraform module, switches it to use the aws efs terraform provider, and switches the NIM operator deployment to use ArgoCD

### Motivation

This allows consolidating the NIM Operator infrastructure back into the base and make it reusable across other infrastructures

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
