### PR TITLE
Update g6e instances and default region to us-west-2 to preserve behavior

### DIFF
--- a/infra/base/terraform/addons.tf
+++ b/infra/base/terraform/addons.tf
@@ -364,6 +364,61 @@ module "data_addons" {
   #---------------------------------------------------------------
   enable_karpenter_resources = true
   karpenter_resources_helm_config = {
+    g6e-gpu-karpenter = {
+      values = [
+        <<-EOT
+      name: g6e-gpu-karpenter
+      clusterName: ${module.eks.cluster_name}
+      ec2NodeClass:
+        amiFamily: Bottlerocket
+        karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
+        subnetSelectorTerms:
+          id: ${module.vpc.private_subnets[2]}
+        securityGroupSelectorTerms:
+          tags:
+            Name: ${module.eks.cluster_name}-node
+        instanceStorePolicy: RAID0
+        blockDeviceMappings:
+          # Root device
+          - deviceName: /dev/xvda
+            ebs:
+              volumeSize: 50Gi
+              volumeType: gp3
+              encrypted: true
+
+      nodePool:
+        labels:
+          - instanceType: g6e-gpu-karpenter
+          - type: karpenter
+          - gpuType: l40s
+        taints:
+          - key: nvidia.com/gpu
+            value: "Exists"
+            effect: "NoSchedule"
+        requirements:
+          - key: "karpenter.k8s.aws/instance-family"
+            operator: In
+            values: ["g6e"]
+          - key: "karpenter.k8s.aws/instance-size"
+            operator: In
+            values: [ "2xlarge", "4xlarge", "8xlarge", "12xlarge", "16xlarge", "24xlarge", "48xlarge" ]
+          - key: "kubernetes.io/arch"
+            operator: In
+            values: ["amd64"]
+          - key: "karpenter.sh/capacity-type"
+            operator: In
+            values: ["spot", "on-demand"]
+        limits:
+          cpu: 1000
+        disruption:
+          consolidationPolicy: WhenEmpty
+          consolidateAfter: 300s
+          expireAfter: 720h
+        weight: 100
+      EOT
+      ]
+    }
+
     g6-gpu-karpenter = {
       values = [
         <<-EOT
@@ -418,6 +473,7 @@ module "data_addons" {
       EOT
       ]
     }
+
     g5-gpu-karpenter = {
       values = [
         <<-EOT

--- a/infra/base/terraform/variables.tf
+++ b/infra/base/terraform/variables.tf
@@ -6,7 +6,7 @@ variable "name" {
 
 variable "region" {
   description = "region"
-  default     = "us-east-1"
+  default     = "us-west-2"
   type        = string
 }
 

--- a/website/docs/blueprints/inference/GPUs/nvidia-nim-operator.md
+++ b/website/docs/blueprints/inference/GPUs/nvidia-nim-operator.md
@@ -229,11 +229,12 @@ $ kubectl get nodepools
 
 ```
 NAME                NODECLASS           NODES   READY   AGE
-g5-gpu-karpenter    g5-gpu-karpenter    1       True    47h
-g6-gpu-karpenter    g6-gpu-karpenter    0       True    7h56m
-inferentia-inf2     inferentia-inf2     0       False   47h
-trainium-trn1       trainium-trn1       0       False   47h
-x86-cpu-karpenter   x86-cpu-karpenter   0       True    47h
+g5-gpu-karpenter    g5-gpu-karpenter    0       True    7h3m
+g6-gpu-karpenter    g6-gpu-karpenter    1       True    7h3m
+g6e-gpu-karpenter   g6e-gpu-karpenter   0       True    55m
+inferentia-inf2     inferentia-inf2     0       True    7h3m
+trainium-trn1       trainium-trn1       0       True    7h3m
+x86-cpu-karpenter   x86-cpu-karpenter   3       True    7h3m
 ```
 
 </details>

--- a/website/docs/blueprints/inference/GPUs/ray-vllm-deepseek.md
+++ b/website/docs/blueprints/inference/GPUs/ray-vllm-deepseek.md
@@ -74,10 +74,7 @@ For example, set your `export AWS_DEFAULT_REGION="<REGION>"` to the desired regi
 **Step2**: Run the installation script.
 
 ```bash
-cd ai-on-eks/infra/jark-stack/terraform && chmod +x install.sh
-```
-
-```bash
+cd ai-on-eks/infra/jark-stack/ && chmod +x install.sh
 ./install.sh
 ```
 

--- a/website/docs/blueprints/inference/GPUs/ray-vllm-deepseek.md
+++ b/website/docs/blueprints/inference/GPUs/ray-vllm-deepseek.md
@@ -106,9 +106,13 @@ kubectl get nodepools
 ```
 
 ```text
-NAME                NODECLASS
-g5-gpu-karpenter    g5-gpu-karpenter
-x86-cpu-karpenter   x86-cpu-karpenter
+NAME                NODECLASS           NODES   READY   AGE
+g5-gpu-karpenter    g5-gpu-karpenter    0       True    6h59m
+g6-gpu-karpenter    g6-gpu-karpenter    1       True    6h59m
+g6e-gpu-karpenter   g6e-gpu-karpenter   0       True    51m
+inferentia-inf2     inferentia-inf2     0       True    6h59m
+trainium-trn1       trainium-trn1       0       True    6h59m
+x86-cpu-karpenter   x86-cpu-karpenter   3       True    6h59m
 ```
 
 Verify the NVIDIA Device plugin

--- a/website/docs/blueprints/inference/GPUs/vLLM-rayserve.md
+++ b/website/docs/blueprints/inference/GPUs/vLLM-rayserve.md
@@ -108,9 +108,13 @@ kubectl get nodepools
 ```
 
 ```text
-NAME                NODECLASS
-g5-gpu-karpenter    g5-gpu-karpenter
-x86-cpu-karpenter   x86-cpu-karpenter
+NAME                NODECLASS           NODES   READY   AGE
+g5-gpu-karpenter    g5-gpu-karpenter    0       True    6h59m
+g6-gpu-karpenter    g6-gpu-karpenter    1       True    6h59m
+g6e-gpu-karpenter   g6e-gpu-karpenter   0       True    51m
+inferentia-inf2     inferentia-inf2     0       True    6h59m
+trainium-trn1       trainium-trn1       0       True    6h59m
+x86-cpu-karpenter   x86-cpu-karpenter   3       True    6h59mr
 ```
 
 Verify the NVIDIA Device plugin

--- a/website/docs/blueprints/inference/GPUs/vLLM-rayserve.md
+++ b/website/docs/blueprints/inference/GPUs/vLLM-rayserve.md
@@ -76,10 +76,7 @@ For example, set your `export AWS_DEFAULT_REGION="<REGION>"` to the desired regi
 **Step2**: Run the installation script.
 
 ```bash
-cd ai-on-eks/infra/jark-stack/terraform && chmod +x install.sh
-```
-
-```bash
+cd ai-on-eks/infra/jark-stack/ && chmod +x install.sh
 ./install.sh
 ```
 


### PR DESCRIPTION
### What does this PR do?
Documentation fix and restore default behavior in variables to deploy to us-west-2 (as suggested by the documentation). 

* Restore default behavior to deploy to us-west-2 as previous repository data-on-eks
* Add g6e karpenter nodepool
* Fix path of `install.sh` in documentation that uses jark-stack, there is not such file `ai-on-eks/infra/jark-stack/terraform/install.sh` in the main branch, only after executing `ai-on-eks/infra/jark-stack/install.sh` which will copy the base terraform and it's install.sh and execute it.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
Fix documentation, restore behavior that is as described in documentation and previous data-on-eks repo and update to have g6e instances if necessary to test some models as it has better GPU than g6 instances.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

```
pre-commit run -a
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for merge conflicts................................................Passed
detect private key.......................................................Passed
detect aws credentials...................................................Passed
Terraform fmt............................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
Terraform validate.......................................................Passed
TruffleHog...............................................................Passed
```

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->

```
kubectl get nodepools
```
```
NAME                NODECLASS           NODES   READY   AGE
g5-gpu-karpenter    g5-gpu-karpenter    0       True    6h59m
g6-gpu-karpenter    g6-gpu-karpenter    1       True    6h59m
g6e-gpu-karpenter   g6e-gpu-karpenter   0       True    51m
inferentia-inf2     inferentia-inf2     0       True    6h59m
trainium-trn1       trainium-trn1       0       True    6h59m
x86-cpu-karpenter   x86-cpu-karpenter   3       True    6h59m
```