### PR TITLE
fix efs resource unavailable in non-efs deployments and a little cleanup

### DIFF
--- a/infra/aibrix/terraform/blueprint.tfvars
+++ b/infra/aibrix/terraform/blueprint.tfvars
@@ -1,3 +1,28 @@
 name                = "aibrix-on-eks"
 enable_aibrix_stack = true
 enable_argocd       = true
+# region              = "us-west-2"
+# eks_cluster_version = "1.32"
+
+# -------------------------------------------------------------------------------------
+# EKS Addons Configuration
+#
+# These are the EKS Cluster Addons managed by Terrafrom stack.
+# You can enable or disable any addon by setting the value to `true` or `false`.
+#
+# If you need to add a new addon that isn't listed here:
+# 1. Add the addon name to the `enable_cluster_addons` variable in `base/terraform/variables.tf`
+# 2. Update the `locals.cluster_addons` logic in `eks.tf` to include any required configuration
+#
+# -------------------------------------------------------------------------------------
+
+# enable_cluster_addons = {
+#   coredns                         = true
+#   kube-proxy                      = true
+#   vpc-cni                         = true
+#   eks-pod-identity-agent          = true
+#   aws-ebs-csi-driver              = true
+#   metrics-server                  = true
+#   eks-node-monitoring-agent       = false
+#   amazon-cloudwatch-observability = true
+# }

--- a/infra/base/terraform/argocd_addons.tf
+++ b/infra/base/terraform/argocd_addons.tf
@@ -3,11 +3,13 @@ resource "kubectl_manifest" "ai_ml_observability_yaml" {
   yaml_body  = file("${path.module}/argocd-addons/ai-ml-observability.yaml")
   depends_on = [module.eks_blueprints_addons]
 }
+
 resource "kubectl_manifest" "aibrix_dependency_yaml" {
   count      = var.enable_aibrix_stack ? 1 : 0
   yaml_body  = templatefile("${path.module}/argocd-addons/aibrix-dependency.yaml", { aibrix_version = var.aibrix_stack_version })
   depends_on = [module.eks_blueprints_addons]
 }
+
 resource "kubectl_manifest" "aibrix_core_yaml" {
   count      = var.enable_aibrix_stack ? 1 : 0
   yaml_body  = templatefile("${path.module}/argocd-addons/aibrix-core.yaml", { aibrix_version = var.aibrix_stack_version })

--- a/infra/base/terraform/efs.tf
+++ b/infra/base/terraform/efs.tf
@@ -37,6 +37,7 @@ module "efs" {
 # a PersistentVolumeClaim (PVC) with ReadWriteMany access mode.
 #---------------------------------------------------------------
 resource "kubernetes_storage_class_v1" "efs" {
+  count = var.enable_aws_efs_csi_driver ? 1 : 0
   metadata {
     name = "efs-sc-dynamic"
   }

--- a/website/docs/infra/ai-ml/index.md
+++ b/website/docs/infra/ai-ml/index.md
@@ -36,35 +36,39 @@ Each stack inherits the `base` stack's components. These components include:
 
 ### Deployment
 
-| Variable Name                            | Description                                        | Default                 |
-|------------------------------------------|----------------------------------------------------|-------------------------|
-| `name`                                   | The name of the Kubernetes cluster                 | `ai-stack`              |
-| `region`                                 | The region for the cluster                         | us-east-1               |
-| `eks_cluster_version`                    | The version of EKS to use                          | 1.32                    |
-| `vpc_cidr`                               | The CIDR used for the VPC                          | `10.1.0.0/21`           |
-| `secondary_cidr_blocks`                  | Secondary CIDR for the VPC                         | `100.64.0.0/16`         |
-| `enable_aws_cloudwatch_metrics`          | Enable the AWS Cloudwatch Metrics addon            | `false`                 |
-| `bottlerocket_data_disk_snapshot_id`     | Attach a snapshot ID to the deployed nodes         | `""`                    |
-| `enable_aws_efs_csi_driver`              | Enable the AWS EFS CSI driver                      | `false`                 |
-| `enable_aws_efa_k8s_device_plugin`       | Enable the AWS EFA device plugin                   | `false`                 |
-| `enable_aws_fsx_csi_driver`              | Enable the FSx device plugin                       | `false`                 |
-| `deploy_fsx_volume`                      | Deploy a simple FSx volume                         | `false`                 |
-| `enable_amazon_prometheus`               | Enable Amazon Managed Prometheus                   | `false`                 |
-| `enable_amazon_emr`                      | Set up Amazon EMR                                  | `false`                 |
-| `enable_kube_prometheus_stack`           | Enable the Kube Prometheus addon                   | `false`                 |
-| `enable_kubecost`                        | Enable Kubecost                                    | `false`                 |
-| `enable_argo_workflows`                  | Enable Argo Workflow                               | `false`                 |
-| `enable_argo_events`                     | Enable Argo Events                                 | `false`                 |
-| `enable_mlflow_tracking`                 | Enable MLFlow Tracking                             | `false`                 |
-| `enable_jupyterhub`                      | Enable JupyterHub                                  | `false`                 |
-| `enable_volcano`                         | Enable Volcano                                     | `false`                 |
-| `enable_kuberay_operator`                | Enable KubeRay                                     | `false`                 |
-| `huggingface_token`                      | Hugging Face token to use in environment           | `DUMMY_TOKEN_REPLACE_ME` |
-| `enable_rayserve_ha_elastic_cache_redis` | Enable Rayserve high availability using ElastiCache | `false`                 |
-| `enable_torchx_etcd`                     | Enable etcd for torchx                             | `false`                 |
-| `enable_mpi_operator`                    | Enable the MPIO perator                            | `false`                 |
-| `enable_aibrix_stack`                    | Enable the AIBrix stack                            | `false`                 |
-| `aibrix_stack_version`                   | AIBrix Stack version                               | `v0.2.1`                |
+| Variable Name                            | Description                                         | Default                  |
+|------------------------------------------|-----------------------------------------------------|--------------------------|
+| `name`                                   | The name of the Kubernetes cluster                  | `ai-stack`               |
+| `region`                                 | The region for the cluster                          | us-east-1                |
+| `eks_cluster_version`                    | The version of EKS to use                           | 1.32                     |
+| `vpc_cidr`                               | The CIDR used for the VPC                           | `10.1.0.0/21`            |
+| `secondary_cidr_blocks`                  | Secondary CIDR for the VPC                          | `100.64.0.0/16`          |
+| `enable_database_subnets`                | Whether or not to enable the database subnets       | `false`                  |
+| `enable_aws_cloudwatch_metrics`          | Enable the AWS Cloudwatch Metrics addon             | `false`                  |
+| `bottlerocket_data_disk_snapshot_id`     | Attach a snapshot ID to the deployed nodes          | `""`                     |
+| `enable_aws_efs_csi_driver`              | Enable the AWS EFS CSI driver                       | `false`                  |
+| `enable_aws_efa_k8s_device_plugin`       | Enable the AWS EFA device plugin                    | `false`                  |
+| `enable_aws_fsx_csi_driver`              | Enable the FSx device plugin                        | `false`                  |
+| `deploy_fsx_volume`                      | Deploy a simple FSx volume                          | `false`                  |
+| `enable_amazon_prometheus`               | Enable Amazon Managed Prometheus                    | `false`                  |
+| `enable_amazon_emr`                      | Set up Amazon EMR                                   | `false`                  |
+| `enable_kube_prometheus_stack`           | Enable the Kube Prometheus addon                    | `false`                  |
+| `enable_kubecost`                        | Enable Kubecost                                     | `false`                  |
+| `enable_ai_ml_observability_stack`       | Enable AI/ML observability addon                    | `false`                  |
+| `enable_argo_workflows`                  | Enable Argo Workflow                                | `false`                  |
+| `enable_argo_events`                     | Enable Argo Events                                  | `false`                  |
+| `enable_argocd`                          | Enable ArgoCD addon                                 | `false`                  |
+| `enable_mlflow_tracking`                 | Enable MLFlow Tracking                              | `false`                  |
+| `enable_jupyterhub`                      | Enable JupyterHub                                   | `false`                  |
+| `enable_volcano`                         | Enable Volcano                                      | `false`                  |
+| `enable_kuberay_operator`                | Enable KubeRay                                      | `false`                  |
+| `huggingface_token`                      | Hugging Face token to use in environment            | `DUMMY_TOKEN_REPLACE_ME` |
+| `enable_rayserve_ha_elastic_cache_redis` | Enable Rayserve high availability using ElastiCache | `false`                  |
+| `enable_torchx_etcd`                     | Enable etcd for torchx                              | `false`                  |
+| `enable_mpi_operator`                    | Enable the MPI Operator                             | `false`                  |
+| `enable_aibrix_stack`                    | Enable the AIBrix stack                             | `false`                  |
+| `aibrix_stack_version`                   | AIBrix Stack version                                | `v0.2.1`                 |
+
 ### JupyterHub
 
 | Variable Name                 | Description                                                                           | Default |


### PR DESCRIPTION
### What does this PR do?

Fixes an issue with a EFS resource attempting to be deployed when used without EFS causing terraform failures. Also fixes some formatting and missing variables in the website

### Motivation

Deployment of AIBrix stack was broken

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
![image](https://github.com/user-attachments/assets/12bbbbd0-0379-491c-a944-51f5e6a302b4)
