### PR TITLE
fix: Enable argocd by default and fix dcgm deployment without monitoring

### DIFF
--- a/infra/base/terraform/argocd-addons/nvidia-dcgm-helm.yaml
+++ b/infra/base/terraform/argocd-addons/nvidia-dcgm-helm.yaml
@@ -22,7 +22,7 @@ spec:
             cpu: "100m"
 
         serviceMonitor:
-          enabled: {service_monitor_enabled}
+          enabled: ${service_monitor_enabled}
           additionalLabels:
             release: kube-prometheus-stack
 

--- a/infra/base/terraform/argocd-addons/nvidia-dcgm-helm.yaml
+++ b/infra/base/terraform/argocd-addons/nvidia-dcgm-helm.yaml
@@ -22,6 +22,7 @@ spec:
             cpu: "100m"
 
         serviceMonitor:
+          enabled: {service_monitor_enabled}
           additionalLabels:
             release: kube-prometheus-stack
 

--- a/infra/base/terraform/argocd_addons.tf
+++ b/infra/base/terraform/argocd_addons.tf
@@ -8,15 +8,21 @@ resource "kubectl_manifest" "ai_ml_observability_yaml" {
 }
 
 resource "kubectl_manifest" "aibrix_dependency_yaml" {
-  count      = var.enable_aibrix_stack ? 1 : 0
-  yaml_body  = templatefile("${path.module}/argocd-addons/aibrix-dependency.yaml", { aibrix_version = var.aibrix_stack_version })
-  depends_on = [module.eks_blueprints_addons]
+  count     = var.enable_aibrix_stack ? 1 : 0
+  yaml_body = templatefile("${path.module}/argocd-addons/aibrix-dependency.yaml", { aibrix_version = var.aibrix_stack_version })
+
+  depends_on = [
+    module.eks_blueprints_addons
+  ]
 }
 
 resource "kubectl_manifest" "aibrix_core_yaml" {
-  count      = var.enable_aibrix_stack ? 1 : 0
-  yaml_body  = templatefile("${path.module}/argocd-addons/aibrix-core.yaml", { aibrix_version = var.aibrix_stack_version })
-  depends_on = [module.eks_blueprints_addons]
+  count     = var.enable_aibrix_stack ? 1 : 0
+  yaml_body = templatefile("${path.module}/argocd-addons/aibrix-core.yaml", { aibrix_version = var.aibrix_stack_version })
+
+  depends_on = [
+    module.eks_blueprints_addons
+  ]
 }
 
 resource "kubectl_manifest" "nvidia_nim_yaml" {
@@ -29,7 +35,7 @@ resource "kubectl_manifest" "nvidia_nim_yaml" {
 }
 
 resource "kubectl_manifest" "nvidia_dcgm_helm" {
-  yaml_body = file("${path.module}/argocd-addons/nvidia-dcgm-helm.yaml")
+  yaml_body = templatefile("${path.module}/argocd-addons/nvidia-dcgm-helm.yaml", { service_monitor_enabled = var.enable_ai_ml_observability_stack })
 
   depends_on = [
     module.eks_blueprints_addons

--- a/infra/base/terraform/variables.tf
+++ b/infra/base/terraform/variables.tf
@@ -125,7 +125,7 @@ variable "enable_argo_events" {
 variable "enable_argocd" {
   description = "Enable ArgoCD addon"
   type        = bool
-  default     = false
+  default     = true
 }
 variable "enable_mlflow_tracking" {
   description = "Enable MLFlow Tracking"


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/ai-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

Fixes: #98 
This PR enables ArgoCD by default to deploy DCGM and other addons after the EKS cluster is created. It also fixes a scenario where DCGM may be deployed without the CoreOS monitoring CRDs, which causes ArgoCD to fail deploying DCGM

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
