### PR TITLE
feat: Creating consistent ray/vllm deployments

### DIFF
--- a/blueprints/inference/gpu/ray-vllm/client.py
+++ b/blueprints/inference/gpu/ray-vllm/client.py
@@ -1,0 +1,26 @@
+from openai import OpenAI
+
+model = "" # model name in org/model format
+port = "" # port number being forwarded
+prompt = "Hello" # prompt
+client = OpenAI(
+    base_url=f"http://localhost:{port}/v1",
+    api_key="token",
+)
+
+# Chat Completion
+response = client.chat.completions.create(
+    model=model,
+    messages=[
+        {"role": "user", "content": f"{prompt}"}
+    ]
+)
+print(response.choices[0].message)
+
+# Completions
+
+# response = client.completions.create(
+#     model=model,
+#     prompt=prompt
+# )
+# print(response.choices[0].text)

--- a/blueprints/inference/gpu/ray-vllm/fluentbit-configmap.yaml
+++ b/blueprints/inference/gpu/ray-vllm/fluentbit-configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentbit-config
+data:
+  fluent-bit.conf: |
+    [INPUT]
+        Name tail
+        Path /tmp/ray/session_latest/logs/*
+        Tag ray
+        Path_Key true
+        Refresh_Interval 5
+    [FILTER]
+        Name modify
+        Match ray
+        Add POD_LABELS ${POD_LABELS}
+    [OUTPUT]
+        Name stdout

--- a/blueprints/inference/gpu/ray-vllm/llama-3.2-1b.env
+++ b/blueprints/inference/gpu/ray-vllm/llama-3.2-1b.env
@@ -1,0 +1,25 @@
+# Kubernetes
+SERVICE_NAME=llama-32-1b-ray # must start with lowercase, contain only alphanumeric or dashes and end in with alphanumeric
+SERVICE_NAMESPACE=default
+
+# Infrastructure
+RAY_VERSION=2.47.0
+VLLM_VERSION=0.9.1
+PYTHON_VERSION=3.11
+NUM_GPUS=1
+
+# Node Scaling Configuration
+MIN_REPLICAS=1
+MAX_REPLICAS=2
+
+# Model Specific
+MODEL_ID=NousResearch/Llama-3.2-1B
+GPU_MEMORY_UTILIZATION="0.8"
+MAX_MODEL_LEN=8192
+MAX_NUM_SEQ=4
+MAX_NUM_BATCHED_TOKENS=8192
+TOKENIZER_POOL_SIZE=4
+MAX_PARALLEL_LOADING_WORKERS=2
+PIPELINE_PARALLEL_SIZE=1
+TENSOR_PARALLEL_SIZE=1
+ENABLE_PREFIX_CACHING=true

--- a/blueprints/inference/gpu/ray-vllm/mistral-small-24B-instruct-2501.env
+++ b/blueprints/inference/gpu/ray-vllm/mistral-small-24B-instruct-2501.env
@@ -1,0 +1,25 @@
+# Kubernetes
+SERVICE_NAME=mistral-small-24B-instruct-2501 # must start with lowercase, contain only alphanumeric or dashes and end in with alphanumeric
+SERVICE_NAMESPACE=default
+
+# Infrastructure
+RAY_VERSION=2.46.0
+VLLM_VERSION=0.9.0
+PYTHON_VERSION=3.11
+NUM_GPUS=4
+
+# Node Scaling Configuration
+MIN_REPLICAS=1
+MAX_REPLICAS=2
+
+# Model Specific
+MODEL_ID=mistralai/Mistral-Small-24B-Instruct-2501
+GPU_MEMORY_UTILIZATION="0.9"
+MAX_MODEL_LEN=8192
+MAX_NUM_SEQ=4
+MAX_NUM_BATCHED_TOKENS=32768
+TOKENIZER_POOL_SIZE=4
+MAX_PARALLEL_LOADING_WORKERS=2
+PIPELINE_PARALLEL_SIZE=1
+TENSOR_PARALLEL_SIZE=4
+ENABLE_PREFIX_CACHING=true

--- a/blueprints/inference/gpu/ray-vllm/ray-vllm-configmap.yaml
+++ b/blueprints/inference/gpu/ray-vllm/ray-vllm-configmap.yaml
@@ -1,0 +1,199 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ray-vllm-serve
+  namespace: default
+data:
+  vllm_serve.py: |
+    import json
+    import re
+    from typing import AsyncGenerator, List, Optional
+    from fastapi import BackgroundTasks, FastAPI
+    from prometheus_client import make_asgi_app
+    from starlette.requests import Request
+    from starlette.responses import StreamingResponse, Response, JSONResponse
+    from starlette.routing import Mount
+    from vllm.engine.arg_utils import AsyncEngineArgs
+    from vllm.engine.async_llm_engine import AsyncLLMEngine
+    from vllm.entrypoints.openai.serving_models import BaseModelPath, OpenAIServingModels
+    from vllm.sampling_params import SamplingParams
+    from vllm.utils import random_uuid
+    from ray import serve
+    from starlette.requests import Request
+    from starlette.responses import StreamingResponse, JSONResponse
+    import os
+    import logging
+    from vllm.entrypoints.openai.serving_chat import OpenAIServingChat
+    from vllm.entrypoints.openai.serving_completion import OpenAIServingCompletion
+    from vllm.transformers_utils.config import get_config
+    from huggingface_hub import login
+    from vllm.entrypoints.openai.protocol import (
+        CompletionRequest,
+        CompletionResponse,
+        ChatCompletionRequest,
+        ChatCompletionResponse,
+        ErrorResponse,
+    )
+
+    # Environment and configuration setup
+    logger = logging.getLogger("ray.serve")
+    app = FastAPI()
+
+
+    def get_model_config(model_path: str) -> dict:
+        try:
+            config = get_config(model_path)
+            return {
+                "architecture": config.architectures[0] if config.architectures else None,
+                "vocab_size": config.vocab_size,
+                "hidden_size": config.hidden_size,
+                "num_hidden_layers": config.num_hidden_layers,
+                "num_attention_heads": config.num_attention_heads,
+            }
+        except Exception as e:
+            logger.warning(f"Error reading model config: {e}")
+            return {}
+
+
+    @serve.deployment(name="serve",
+                      autoscaling_config={"min_replicas": 1, "max_replicas": 2},
+                      )
+    @serve.ingress(app)
+    class VLLMDeployment:
+        def __init__(self, response_role: str = "assistant",
+                     chat_template: Optional[str] = None, **kwargs):
+            # setup vLLM metrics for scraping
+            route = Mount("/metrics", make_asgi_app())
+            # Workaround for 307 Redirect for /metrics
+            route.path_regex = re.compile('^/metrics(?P<path>.*)$')
+            app.routes.append(route)
+
+            hf_token = os.getenv("HUGGING_FACE_HUB_TOKEN")
+            if not hf_token:
+                raise ValueError("HUGGING_FACE_HUB_TOKEN environment variable is not set")
+            login(token=hf_token)
+            logger.info("Successfully logged in to Hugging Face Hub")
+
+            self.engine_args = AsyncEngineArgs(
+                model=os.getenv("MODEL_ID", "NousResearch/Llama-3.2-1B"),
+                # Model identifier from Hugging Face Hub or local path.
+                dtype="auto",
+                # Automatically determine the data type (e.g., float16 or float32) for model weights and computations.
+                gpu_memory_utilization=float(os.getenv("GPU_MEMORY_UTILIZATION", "0.8")),
+                # Percentage of GPU memory to utilize, reserving some for overhead.
+                max_model_len=int(os.getenv("MAX_MODEL_LEN", "8192")),
+                # Maximum sequence length (in tokens) the model can handle, including both input and output tokens.
+                max_num_seqs=int(os.getenv("MAX_NUM_SEQ", "4")),
+                # Maximum number of sequences (requests) to process in parallel.
+                max_num_batched_tokens=int(os.getenv("MAX_NUM_BATCHED_TOKENS", "8192")),
+                # Maximum number of tokens processed in a single batch across all sequences (max_model_len * max_num_seqs).
+                trust_remote_code=True,
+                # Allow execution of untrusted code from the model repository (use with caution).
+                enable_chunked_prefill=False,
+                # Disable chunked prefill to avoid compatibility issues with prefix caching.
+                tokenizer_pool_size=int(os.getenv("TOKENIZER_POOL_SIZE", "4")),
+                # Number of tokenizer instances to handle concurrent requests efficiently.
+                tokenizer_pool_type="ray",  # Pool type for tokenizers; 'ray' uses Ray for distributed processing.
+                # max_parallel_loading_workers=int(os.getenv("MAX_PARALLEL_LOADING_WORKERS", "2")),  # Number of parallel workers to load the model concurrently.
+                pipeline_parallel_size=int(os.getenv("PIPELINE_PARALLEL_SIZE", "1")),
+                # Number of pipeline parallelism stages; typically set to 1 unless using model parallelism.
+                tensor_parallel_size=int(os.getenv("TENSOR_PARALLEL_SIZE", "1")),
+                # Number of tensor parallelism stages; typically set to 1 unless using model parallelism.
+                enable_prefix_caching=bool(os.getenv("ENABLE_PREFIX_CACHING", "true")),
+                # Enable prefix caching to improve performance for similar prompt prefixes.
+                # worker_use_ray=True,
+                enforce_eager=True,
+            )
+            self.openai_serving_chat = None
+            self.openai_serving = None
+            self.response_role = response_role
+            self.chat_template = chat_template
+            self.engine = AsyncLLMEngine.from_engine_args(self.engine_args)
+            self.max_model_len = self.engine_args.max_model_len
+            logger.info(f"VLLM Engine initialized with max_model_len: {self.max_model_len}")
+
+        @app.get("/v1/models")
+        async def get_models(self):
+            # Return model information for Open WebUI compatibility
+            model_info = {
+                "object": "list",
+                "data": [
+                    {
+                        "id": self.engine_args.model,
+                        "object": "model",
+                        "owned_by": "organization",
+                        "permission": []
+                    }
+                ]
+            }
+            return JSONResponse(content=model_info)
+
+        @app.post("/v1/completions")
+        async def create_completion(self,
+                                    request: CompletionRequest, raw_request: Request):
+            if not self.openai_serving:
+                model_config = await self.engine.get_model_config()
+                base_model_paths = [BaseModelPath(name=self.engine_args.model, model_path=self.engine_args.model)]
+                openai_serving_models = OpenAIServingModels(
+                    engine_client=self.engine,
+                    model_config=model_config,
+                    base_model_paths=base_model_paths,
+                )
+                self.openai_serving = OpenAIServingCompletion(
+                    engine_client=self.engine,
+                    model_config=model_config,
+                    models=openai_serving_models,
+                    request_logger=None
+                )
+
+            logger.info(f"Request: {request}")
+            generator = await self.openai_serving.create_completion(
+                request, raw_request
+            )
+            if isinstance(generator, ErrorResponse):
+                return JSONResponse(
+                    content=generator.model_dump(), status_code=generator.code
+                )
+            if request.stream:
+                return StreamingResponse(content=generator, media_type="text/event-stream")
+            else:
+                assert isinstance(generator, CompletionResponse)
+                return JSONResponse(content=generator.model_dump())
+
+        @app.post("/v1/chat/completions")
+        async def create_chat_completion(
+                self, request: ChatCompletionRequest, raw_request: Request
+        ):
+            if not self.openai_serving_chat:
+                model_config = await self.engine.get_model_config()
+                base_model_paths = [BaseModelPath(name=self.engine_args.model, model_path=self.engine_args.model)]
+                openai_serving_models = OpenAIServingModels(
+                    engine_client=self.engine,
+                    model_config=model_config,
+                    base_model_paths=base_model_paths,
+                )
+                self.openai_serving_chat = OpenAIServingChat(
+                    engine_client=self.engine,
+                    model_config=model_config,
+                    models=openai_serving_models,
+                    response_role=self.response_role,
+                    request_logger=None,
+                    chat_template=self.chat_template,
+                    chat_template_content_format="auto"
+                )
+            logger.info(f"Request: {request}")
+            generator = await self.openai_serving_chat.create_chat_completion(
+                request, raw_request
+            )
+            if isinstance(generator, ErrorResponse):
+                return JSONResponse(
+                    content=generator.model_dump(), status_code=generator.code
+                )
+            if request.stream:
+                return StreamingResponse(content=generator, media_type="text/event-stream")
+            else:
+                assert isinstance(generator, ChatCompletionResponse)
+                return JSONResponse(content=generator.model_dump())
+
+
+    deployment = VLLMDeployment.bind()

--- a/blueprints/inference/gpu/ray-vllm/ray-vllm-deployment.yaml
+++ b/blueprints/inference/gpu/ray-vllm/ray-vllm-deployment.yaml
@@ -1,0 +1,212 @@
+apiVersion: ray.io/v1
+kind: RayService
+metadata:
+  name: $SERVICE_NAME
+  namespace: $SERVICE_NAMESPACE
+spec:
+  deploymentUnhealthySecondThreshold: 900
+  rayClusterConfig:
+    headGroupSpec:
+      headService:
+        metadata:
+          name: $SERVICE_NAME
+          namespace: $SERVICE_NAMESPACE
+      rayStartParams:
+        dashboard-host: 0.0.0.0
+        num-cpus: '0'
+      template:
+        spec:
+          containers:
+            - env:
+                - name: VLLM_LOGGING_LEVEL
+                  value: DEBUG
+                - name: HUGGING_FACE_HUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      key: token
+                      name: hf-token
+                - name: LD_LIBRARY_PATH
+                  value: /home/ray/anaconda3/lib
+                - name: RAY_GRAFANA_HOST
+                  value: >-
+                    http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local
+                - name: RAY_PROMETHEUS_HOST
+                  value: >-
+                    http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+                - name: RAY_GRAFANA_IFRAME_HOST
+                  value: http://localhost:3000
+              image: rayproject/ray:$RAY_VERSION-py$PYTHON_VERSION
+              imagePullPolicy: Always
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                      - /bin/sh
+                      - '-c'
+                      - ray stop
+              name: head
+              ports:
+                - containerPort: 6379
+                  name: gcs
+                  protocol: TCP
+                - containerPort: 8265
+                  name: dashboard
+                  protocol: TCP
+                - containerPort: 10001
+                  name: client
+                  protocol: TCP
+                - containerPort: 8000
+                  name: serve
+                  protocol: TCP
+              resources:
+                limits:
+                  cpu: 4
+                  memory: 20Gi
+                requests:
+                  cpu: 4
+                  memory: 20Gi
+              volumeMounts:
+                - mountPath: /tmp/ray
+                  name: ray-logs
+                - mountPath: /home/ray/vllm_serve.py
+                  subPath: vllm_serve.py
+                  name: vllm-script
+            - name: fluentbit
+              image: fluent/fluent-bit:3.2.2
+              # Get Kubernetes metadata via downward API
+              env:
+                - name: POD_LABELS
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.labels['ray.io/cluster']
+              # These resource requests for Fluent Bit should be sufficient in production.
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+              volumeMounts:
+                - mountPath: /tmp/ray
+                  name: ray-logs
+                - mountPath: /fluent-bit/etc/fluent-bit.conf
+                  subPath: fluent-bit.conf
+                  name: fluentbit-config
+          volumes:
+            - emptyDir: {}
+              name: ray-logs
+            - configMap:
+                items:
+                  - key: vllm_serve.py
+                    path: vllm_serve.py
+                name: ray-vllm-serve
+              name: vllm-script
+            - name: fluentbit-config
+              configMap:
+                name: fluentbit-config
+    rayVersion: "$RAY_VERSION"
+    workerGroupSpecs:
+      - groupName: worker
+        maxReplicas: $MAX_REPLICAS
+        minReplicas: $MIN_REPLICAS
+        numOfHosts: 1
+        rayStartParams: {}
+        replicas: 1
+        template:
+          spec:
+            containers:
+              - env:
+                  - name: LD_LIBRARY_PATH
+                    value: /home/ray/anaconda3/lib
+                  - name: VLLM_PORT
+                    value: '8004'
+                  - name: VLLM_LOGGING_LEVEL
+                    value: DEBUG
+                  - name: HUGGING_FACE_HUB_TOKEN
+                    valueFrom:
+                      secretKeyRef:
+                        key: token
+                        name: hf-token
+                  - name: MODEL_ID
+                    value: "$MODEL_ID"
+                  - name: GPU_MEMORY_UTILIZATION
+                    value: "$GPU_MEMORY_UTILIZATION"
+                  - name: MAX_MODEL_LEN
+                    value: "$MAX_MODEL_LEN"
+                  - name: MAX_NUM_SEQ
+                    value: "$MAX_NUM_SEQ"
+                  - name: MAX_NUM_BATCHED_TOKENS
+                    value: "$MAX_NUM_BATCHED_TOKENS"
+                  - name: TOKENIZER_POOL_SIZE
+                    value: "$TOKENIZER_POOL_SIZE"
+                  - name: MAX_PARALLEL_LOADING_WORKERS
+                    value: "$MAX_PARALLEL_LOADING_WORKERS"
+                  - name: PIPELINE_PARALLEL_SIZE
+                    value: "$PIPELINE_PARALLEL_SIZE"
+                  - name: TENSOR_PARALLEL_SIZE
+                    value: "$TENSOR_PARALLEL_SIZE"
+                  - name: ENABLE_PREFIX_CACHING
+                    value: "$ENABLE_PREFIX_CACHING"
+                  - name: NUM_GPUS
+                    value: "$NUM_GPUS"
+                image: rayproject/ray:$RAY_VERSION-py$PYTHON_VERSION-gpu
+                imagePullPolicy: IfNotPresent
+                lifecycle:
+                  preStop:
+                    exec:
+                      command:
+                        - /bin/sh
+                        - '-c'
+                        - ray stop
+                name: worker
+                resources:
+                  limits:
+                    nvidia.com/gpu: $NUM_GPUS
+                  requests:
+                    nvidia.com/gpu: $NUM_GPUS
+                volumeMounts:
+                  - mountPath: /tmp/ray
+                    name: ray-logs
+              - name: fluentbit
+                image: fluent/fluent-bit:3.2.2
+                env:
+                  - name: POD_LABELS
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.labels['ray.io/cluster']
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 128Mi
+                  limits:
+                    cpu: 100m
+                    memory: 128Mi
+                volumeMounts:
+                  - mountPath: /tmp/ray
+                    name: ray-logs
+                  - mountPath: /fluent-bit/etc/fluent-bit.conf
+                    subPath: fluent-bit.conf
+                    name: fluentbit-config
+            tolerations:
+              - key: nvidia.com/gpu
+                operator: Exists
+                effect: NoSchedule
+            volumes:
+              - emptyDir: {}
+                name: ray-logs
+              - name: fluentbit-config
+                configMap:
+                  name: fluentbit-config
+  serveConfigV2: |
+    applications:
+      - name: serve
+        import_path: vllm_serve:deployment
+        runtime_env:
+          pip:
+            - vllm==$VLLM_VERSION
+        deployments:
+          - name: serve
+            ray_actor_options:
+              num_gpus: $NUM_GPUS
+  serviceUnhealthySecondThreshold: 900

--- a/blueprints/inference/gpu/ray-vllm/template.sh
+++ b/blueprints/inference/gpu/ray-vllm/template.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [[ $# -eq 0 ]] ; then
+    echo 'No model file supplied'
+    exit 1
+fi
+
+
+# Load the variables
+set -a  # Mark all variables for export
+source $1 # Read the input variables from the environment file
+set +a  # Stop auto-exporting
+
+PYTHON_VERSION=${PYTHON_VERSION//.}
+# Perform the substitution
+envsubst < ray-vllm-deployment.yaml > $SERVICE_NAME-$(date +%F_%H_%M_%S).yaml

--- a/blueprints/inference/gpu/vllm/llama-3.2-1b.env
+++ b/blueprints/inference/gpu/vllm/llama-3.2-1b.env
@@ -1,0 +1,19 @@
+# Kubernetes
+SERVICE_NAME=llama-32-1b-vllm # must start with lowercase, contain only alphanumeric or dashes and end in with alphanumeric
+SERVICE_NAMESPACE=default
+
+# Infrastructure
+VLLM_VERSION=0.9.1
+NUM_GPUS=1
+
+# Model Specific
+MODEL_ID=NousResearch/Llama-3.2-1B
+GPU_MEMORY_UTILIZATION="0.8"
+MAX_MODEL_LEN=8192
+MAX_NUM_SEQ=4
+MAX_NUM_BATCHED_TOKENS=8192
+TOKENIZER_POOL_SIZE=4
+MAX_PARALLEL_LOADING_WORKERS=2
+PIPELINE_PARALLEL_SIZE=1
+TENSOR_PARALLEL_SIZE=1
+ENABLE_PREFIX_CACHING=false

--- a/blueprints/inference/gpu/vllm/template.sh
+++ b/blueprints/inference/gpu/vllm/template.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ $# -eq 0 ]] ; then
+    echo 'No model file supplied'
+    exit 1
+fi
+
+# Load the variables
+set -a  # Mark all variables for export
+source $1 # Read the input variables from the environment file
+set +a  # Stop auto-exporting
+
+# Perform the substitution
+envsubst < vllm-deployment.yaml > $SERVICE_NAME-$(date +%F_%H_%M_%S).yaml

--- a/blueprints/inference/gpu/vllm/vllm-configmap.yaml
+++ b/blueprints/inference/gpu/vllm/vllm-configmap.yaml
@@ -1,0 +1,185 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vllm-serve
+  namespace: default
+data:
+  vllm_serve.py: |
+    import re
+    from typing import Optional
+    from fastapi import FastAPI
+    from prometheus_client import make_asgi_app
+    from starlette.routing import Mount
+    from vllm.engine.arg_utils import AsyncEngineArgs
+    from vllm.engine.async_llm_engine import AsyncLLMEngine
+    from vllm.entrypoints.openai.serving_models import BaseModelPath,OpenAIServingModels
+    from starlette.requests import Request
+    from starlette.responses import StreamingResponse, JSONResponse
+    import os
+    import logging
+    from vllm.entrypoints.openai.serving_chat import OpenAIServingChat
+    from vllm.entrypoints.openai.serving_completion import OpenAIServingCompletion
+    from vllm.transformers_utils.config import get_config
+    from huggingface_hub import login
+    from vllm.entrypoints.openai.protocol import (
+        CompletionRequest,
+        CompletionResponse,
+        ChatCompletionRequest,
+        ChatCompletionResponse,
+        ErrorResponse,
+    )
+    import uvicorn
+    logger = logging.getLogger("vllm")
+    app = FastAPI()
+    deployment = None
+
+    def get_model_config(model_path: str) -> dict:
+        try:
+            config = get_config(model_path)
+            return {
+                "architecture": config.architectures[0] if config.architectures else None,
+                "vocab_size": config.vocab_size,
+                "hidden_size": config.hidden_size,
+                "num_hidden_layers": config.num_hidden_layers,
+                "num_attention_heads": config.num_attention_heads,
+            }
+        except Exception as e:
+            logger.warning(f"Error reading model config: {e}")
+            return {}
+
+    class VLLMDeployment:
+        def __init__(self, response_role: str = "assistant",
+                     chat_template: Optional[str] = None, **kwargs):
+            route = Mount("/metrics", make_asgi_app())
+            route.path_regex = re.compile('^/metrics(?P<path>.*)$')
+            app.routes.append(route)
+
+            hf_token = os.getenv("HUGGING_FACE_HUB_TOKEN")
+            if not hf_token:
+                raise ValueError("HUGGING_FACE_HUB_TOKEN environment variable is not set")
+            login(token=hf_token)
+            logger.info("Successfully logged in to Hugging Face Hub")
+
+            self.engine_args = AsyncEngineArgs(
+                model=os.getenv("MODEL_ID", "NousResearch/Llama-3.2-1B"),
+                dtype="auto",
+                gpu_memory_utilization=float(os.getenv("GPU_MEMORY_UTILIZATION", "0.8")),
+                max_model_len=int(os.getenv("MAX_MODEL_LEN", "8192")),
+                max_num_seqs=int(os.getenv("MAX_NUM_SEQ", "4")),
+                max_num_batched_tokens=int(os.getenv("MAX_NUM_BATCHED_TOKENS", "8192")),
+                trust_remote_code=True,
+                enable_chunked_prefill=False,
+                tokenizer_pool_size=int(os.getenv("TOKENIZER_POOL_SIZE", "4")),
+                pipeline_parallel_size=int(os.getenv("PIPELINE_PARALLEL_SIZE", "1")),
+                tensor_parallel_size=int(os.getenv("TENSOR_PARALLEL_SIZE", "1")),
+                enable_prefix_caching=bool(os.getenv("ENABLE_PREFIX_CACHING", "true")),
+                enforce_eager=True,
+            )
+            self.openai_serving_chat = None
+            self.openai_serving = None
+            self.response_role = response_role
+            self.chat_template = chat_template
+            self.engine = AsyncLLMEngine.from_engine_args(self.engine_args)
+            self.max_model_len = self.engine_args.max_model_len
+            logger.info(f"VLLM Engine initialized with max_model_len: {self.max_model_len}")
+
+        async def get_models(self):
+            model_info = {
+                "object": "list",
+                "data": [
+                    {
+                        "id": self.engine_args.model,
+                        "object": "model",
+                        "owned_by": "organization",
+                        "permission": []
+                    }
+                ]
+            }
+            return JSONResponse(content=model_info)
+
+        async def create_completion(self, request: CompletionRequest, raw_request: Request):
+            if not self.openai_serving:
+                model_config = await self.engine.get_model_config()
+                base_model_paths = [BaseModelPath(name=self.engine_args.model, model_path=self.engine_args.model)]
+                openai_serving_models = OpenAIServingModels(
+                    engine_client=self.engine,
+                    model_config=model_config,
+                    base_model_paths=base_model_paths,
+                )
+                self.openai_serving = OpenAIServingCompletion(
+                    engine_client=self.engine,
+                    model_config=model_config,
+                    models=openai_serving_models,
+                    request_logger=None
+                )
+            logger.info(f"Request: {request}")
+            generator = await self.openai_serving.create_completion(
+                request, raw_request
+            )
+            if isinstance(generator, ErrorResponse):
+                return JSONResponse(
+                    content=generator.model_dump(), status_code=generator.code
+                )
+            if request.stream:
+                return StreamingResponse(content=generator, media_type="text/event-stream")
+            else:
+                assert isinstance(generator, CompletionResponse)
+                return JSONResponse(content=generator.model_dump())
+
+        async def create_chat_completion(self, request: ChatCompletionRequest, raw_request: Request):
+            if not self.openai_serving_chat:
+                model_config = await self.engine.get_model_config()
+                base_model_paths = [BaseModelPath(name=self.engine_args.model, model_path=self.engine_args.model)]
+                openai_serving_models = OpenAIServingModels(
+                    engine_client=self.engine,
+                    model_config=model_config,
+                    base_model_paths=base_model_paths,
+                )
+                self.openai_serving_chat = OpenAIServingChat(
+                    engine_client=self.engine,
+                    model_config=model_config,
+                    models=openai_serving_models,
+                    response_role=self.response_role,
+                    request_logger=None,
+                    chat_template=self.chat_template,
+                    chat_template_content_format="auto"
+                )
+            logger.info(f"Request: {request}")
+            generator = await self.openai_serving_chat.create_chat_completion(
+                request, raw_request
+            )
+            if isinstance(generator, ErrorResponse):
+                return JSONResponse(
+                    content=generator.model_dump(), status_code=generator.code
+                )
+            if request.stream:
+                return StreamingResponse(content=generator, media_type="text/event-stream")
+            else:
+                assert isinstance(generator, ChatCompletionResponse)
+                return JSONResponse(content=generator.model_dump())
+
+    def create_deployment():
+        global deployment
+        deployment = VLLMDeployment()
+        return deployment
+
+    @app.on_event("startup")
+    async def startup_event():
+        create_deployment()
+
+    @app.get("/v1/models")
+    async def get_models():
+        return await deployment.get_models()
+
+    @app.post("/v1/completions")
+    async def create_completion(request: CompletionRequest, raw_request:
+    Request):
+        return await deployment.create_completion(request, raw_request)
+
+    @app.post("/v1/chat/completions")
+    async def create_chat_completion(request: ChatCompletionRequest,
+                                     raw_request: Request):
+        return await deployment.create_chat_completion(request, raw_request)
+
+    if __name__ == "__main__":
+        uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/blueprints/inference/gpu/vllm/vllm-deployment.yaml
+++ b/blueprints/inference/gpu/vllm/vllm-deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: $SERVICE_NAME
+  namespace: $SERVICE_NAMESPACE
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: $SERVICE_NAME
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: $SERVICE_NAME
+    spec:
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:v$VLLM_VERSION
+          command: ["/bin/sh", "-c"]
+          args: [
+            "python3 vllm_serve.py"
+          ]
+          env:
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token
+                  key: token
+            - name: MODEL_ID
+              value: "$MODEL_ID"
+            - name: GPU_MEMORY_UTILIZATION
+              value: "$GPU_MEMORY_UTILIZATION"
+            - name: MAX_MODEL_LEN
+              value: "$MAX_MODEL_LEN"
+            - name: MAX_NUM_SEQ
+              value: "$MAX_NUM_SEQ"
+            - name: MAX_NUM_BATCHED_TOKENS
+              value: "$MAX_NUM_BATCHED_TOKENS"
+            - name: TOKENIZER_POOL_SIZE
+              value: "$TOKENIZER_POOL_SIZE"
+            - name: MAX_PARALLEL_LOADING_WORKERS
+              value: "$MAX_PARALLEL_LOADING_WORKERS"
+            - name: PIPELINE_PARALLEL_SIZE
+              value: "$PIPELINE_PARALLEL_SIZE"
+            - name: TENSOR_PARALLEL_SIZE
+              value: "$TENSOR_PARALLEL_SIZE"
+            - name: ENABLE_PREFIX_CACHING
+              value: "$ENABLE_PREFIX_CACHING"
+            - name: NUM_GPUS
+              value: "$NUM_GPUS"
+          ports:
+            - containerPort: 8000
+          resources:
+            limits:
+              nvidia.com/gpu: $NUM_GPUS
+            requests:
+              nvidia.com/gpu: $NUM_GPUS
+          volumeMounts:
+            - mountPath: /vllm-workspace/vllm_serve.py
+              subPath: vllm_serve.py
+              name: vllm-script
+      volumes:
+        - configMap:
+            items:
+              - key: vllm_serve.py
+                path: vllm_serve.py
+            name: vllm-serve
+          name: vllm-script
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: $SERVICE_NAME
+  namespace: $SERVICE_NAMESPACE
+spec:
+  selector:
+    app.kubernetes.io/name: $SERVICE_NAME
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000
+  type: ClusterIP

--- a/blueprints/inference/neuron/ray-vllm/dockerfiles/Dockerfile
+++ b/blueprints/inference/neuron/ray-vllm/dockerfiles/Dockerfile
@@ -1,0 +1,46 @@
+# Use the base image
+FROM rayproject/ray:2.47.0-py311
+
+# Set environment variables to non-interactive (this prevents some prompts)
+ENV DEBIAN_FRONTEND=non-interactive
+
+# Switch to root to add Neuron repo and install necessary packages
+USER root
+
+# Set up the Neuron repository and install Neuron packages
+RUN . /etc/os-release && \
+    sudo echo "deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/neuron.list && \
+    sudo wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | apt-key add - && \
+    sudo apt-get update -y && \
+    sudo apt-get install aws-neuronx-dkms aws-neuronx-collectives=2.* aws-neuronx-runtime-lib=2.* aws-neuronx-tools=2.* -y && \
+    sudo apt-get clean && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+# Switch back to a non-root user for the subsequent commands
+USER $USER
+
+# Set pip repository pointing to the Neuron repository and install required Python packages
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com && \
+    python3 -m pip install --no-cache-dir wget awscli neuronx-cc==2.* torch-neuronx torchvision transformers-neuronx huggingface_hub 'cmake>=3.26' packaging 'setuptools-scm>=8' wheel jinja2
+
+# Add Neuron path to PATH
+ENV PATH=/opt/aws/neuron/bin:$PATH
+
+
+# uninstall transformers-neuronx package explicitly to avoid version conflict
+RUN python3 -m pip uninstall -y transformers-neuronx
+
+
+RUN git clone -b v0.9.1 https://github.com/vllm-project/vllm.git && \
+    cd vllm && \
+    pip install -r requirements/neuron.txt && \
+    VLLM_TARGET_DEVICE="neuron" pip install -e .
+
+ENV VLLM_TARGET_DEVICE=neuron
+
+# install transformers-neuronx package as an optional dependencies (for V0)
+# FIXME: `--no-deps` argument is temporarily added to resolve transformers package version conflict
+RUN python3 -m pip install transformers-neuronx --extra-index-url=https://pip.repos.neuron.amazonaws.com -U --no-deps
+
+WORKDIR /home/ray

--- a/blueprints/inference/neuron/ray-vllm/fluentbit-configmap.yaml
+++ b/blueprints/inference/neuron/ray-vllm/fluentbit-configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentbit-config
+data:
+  fluent-bit.conf: |
+    [INPUT]
+        Name tail
+        Path /tmp/ray/session_latest/logs/*
+        Tag ray
+        Path_Key true
+        Refresh_Interval 5
+    [FILTER]
+        Name modify
+        Match ray
+        Add POD_LABELS ${POD_LABELS}
+    [OUTPUT]
+        Name stdout

--- a/blueprints/inference/neuron/ray-vllm/llama-3.1-8b.env
+++ b/blueprints/inference/neuron/ray-vllm/llama-3.1-8b.env
@@ -1,0 +1,25 @@
+# Kubernetes
+SERVICE_NAME=llama-31-8b-ray-nrn # must start with lowercase, contain only alphanumeric or dashes and end in with alphanumeric
+SERVICE_NAMESPACE=default
+
+# Infrastructure
+VLLM_VERSION=0.9.1
+# 1 Neuron device
+NUM_GPUS=1
+
+# Node Scaling Configuration
+MIN_REPLICAS=1
+MAX_REPLICAS=2
+
+# Model Specific
+MODEL_ID=meta-llama/Llama-3.1-8B-Instruct
+GPU_MEMORY_UTILIZATION="0.8"
+MAX_MODEL_LEN=1024
+MAX_NUM_SEQ=1
+MAX_NUM_BATCHED_TOKENS=1024
+TOKENIZER_POOL_SIZE=4
+MAX_PARALLEL_LOADING_WORKERS=2
+PIPELINE_PARALLEL_SIZE=1
+# Neuron has 2 cores per device
+TENSOR_PARALLEL_SIZE=2
+ENABLE_PREFIX_CACHING=false

--- a/blueprints/inference/neuron/ray-vllm/ray-vllm-configmap.yaml
+++ b/blueprints/inference/neuron/ray-vllm/ray-vllm-configmap.yaml
@@ -1,0 +1,199 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ray-vllm-serve
+  namespace: default
+data:
+  vllm_serve.py: |
+    import json
+    import re
+    from typing import AsyncGenerator, List, Optional
+    from fastapi import BackgroundTasks, FastAPI
+    from prometheus_client import make_asgi_app
+    from starlette.requests import Request
+    from starlette.responses import StreamingResponse, Response, JSONResponse
+    from starlette.routing import Mount
+    from vllm.engine.arg_utils import AsyncEngineArgs
+    from vllm.engine.async_llm_engine import AsyncLLMEngine
+    from vllm.entrypoints.openai.serving_models import BaseModelPath, OpenAIServingModels
+    from vllm.sampling_params import SamplingParams
+    from vllm.utils import random_uuid
+    from ray import serve
+    from starlette.requests import Request
+    from starlette.responses import StreamingResponse, JSONResponse
+    import os
+    import logging
+    from vllm.entrypoints.openai.serving_chat import OpenAIServingChat
+    from vllm.entrypoints.openai.serving_completion import OpenAIServingCompletion
+    from vllm.transformers_utils.config import get_config
+    from huggingface_hub import login
+    from vllm.entrypoints.openai.protocol import (
+        CompletionRequest,
+        CompletionResponse,
+        ChatCompletionRequest,
+        ChatCompletionResponse,
+        ErrorResponse,
+    )
+
+    # Environment and configuration setup
+    logger = logging.getLogger("ray.serve")
+    app = FastAPI()
+
+
+    def get_model_config(model_path: str) -> dict:
+        try:
+            config = get_config(model_path)
+            return {
+                "architecture": config.architectures[0] if config.architectures else None,
+                "vocab_size": config.vocab_size,
+                "hidden_size": config.hidden_size,
+                "num_hidden_layers": config.num_hidden_layers,
+                "num_attention_heads": config.num_attention_heads,
+            }
+        except Exception as e:
+            logger.warning(f"Error reading model config: {e}")
+            return {}
+
+
+    @serve.deployment(name="serve",
+                      autoscaling_config={"min_replicas": 1, "max_replicas": 2},
+                      )
+    @serve.ingress(app)
+    class VLLMDeployment:
+        def __init__(self, response_role: str = "assistant",
+                     chat_template: Optional[str] = None, **kwargs):
+            # setup vLLM metrics for scraping
+            route = Mount("/metrics", make_asgi_app())
+            # Workaround for 307 Redirect for /metrics
+            route.path_regex = re.compile('^/metrics(?P<path>.*)$')
+            app.routes.append(route)
+
+            hf_token = os.getenv("HUGGING_FACE_HUB_TOKEN")
+            if not hf_token:
+                raise ValueError("HUGGING_FACE_HUB_TOKEN environment variable is not set")
+            login(token=hf_token)
+            logger.info("Successfully logged in to Hugging Face Hub")
+
+            self.engine_args = AsyncEngineArgs(
+                model=os.getenv("MODEL_ID", "NousResearch/Llama-3.2-1B"),
+                # Model identifier from Hugging Face Hub or local path.
+                dtype="auto",
+                # Automatically determine the data type (e.g., float16 or float32) for model weights and computations.
+                gpu_memory_utilization=float(os.getenv("GPU_MEMORY_UTILIZATION", "0.8")),
+                # Percentage of GPU memory to utilize, reserving some for overhead.
+                max_model_len=int(os.getenv("MAX_MODEL_LEN", "8192")),
+                # Maximum sequence length (in tokens) the model can handle, including both input and output tokens.
+                max_num_seqs=int(os.getenv("MAX_NUM_SEQ", "4")),
+                # Maximum number of sequences (requests) to process in parallel.
+                max_num_batched_tokens=int(os.getenv("MAX_NUM_BATCHED_TOKENS", "8192")),
+                # Maximum number of tokens processed in a single batch across all sequences (max_model_len * max_num_seqs).
+                trust_remote_code=True,
+                # Allow execution of untrusted code from the model repository (use with caution).
+                enable_chunked_prefill=False,
+                # Disable chunked prefill to avoid compatibility issues with prefix caching.
+                tokenizer_pool_size=int(os.getenv("TOKENIZER_POOL_SIZE", "4")),
+                # Number of tokenizer instances to handle concurrent requests efficiently.
+                tokenizer_pool_type="ray",  # Pool type for tokenizers; 'ray' uses Ray for distributed processing.
+                # max_parallel_loading_workers=int(os.getenv("MAX_PARALLEL_LOADING_WORKERS", "2")),  # Number of parallel workers to load the model concurrently.
+                pipeline_parallel_size=int(os.getenv("PIPELINE_PARALLEL_SIZE", "1")),
+                # Number of pipeline parallelism stages; typically set to 1 unless using model parallelism.
+                tensor_parallel_size=int(os.getenv("TENSOR_PARALLEL_SIZE", "1")),
+                # Number of tensor parallelism stages; typically set to 1 unless using model parallelism.
+                enable_prefix_caching=bool(os.getenv("ENABLE_PREFIX_CACHING", "true")),
+                # Enable prefix caching to improve performance for similar prompt prefixes.
+                # worker_use_ray=True,
+                enforce_eager=True,
+            )
+            self.openai_serving_chat = None
+            self.openai_serving = None
+            self.response_role = response_role
+            self.chat_template = chat_template
+            self.engine = AsyncLLMEngine.from_engine_args(self.engine_args)
+            self.max_model_len = self.engine_args.max_model_len
+            logger.info(f"VLLM Engine initialized with max_model_len: {self.max_model_len}")
+
+        @app.get("/v1/models")
+        async def get_models(self):
+            # Return model information for Open WebUI compatibility
+            model_info = {
+                "object": "list",
+                "data": [
+                    {
+                        "id": self.engine_args.model,
+                        "object": "model",
+                        "owned_by": "organization",
+                        "permission": []
+                    }
+                ]
+            }
+            return JSONResponse(content=model_info)
+
+        @app.post("/v1/completions")
+        async def create_completion(self,
+                                    request: CompletionRequest, raw_request: Request):
+            if not self.openai_serving:
+                model_config = await self.engine.get_model_config()
+                base_model_paths = [BaseModelPath(name=self.engine_args.model, model_path=self.engine_args.model)]
+                openai_serving_models = OpenAIServingModels(
+                    engine_client=self.engine,
+                    model_config=model_config,
+                    base_model_paths=base_model_paths,
+                )
+                self.openai_serving = OpenAIServingCompletion(
+                    engine_client=self.engine,
+                    model_config=model_config,
+                    models=openai_serving_models,
+                    request_logger=None
+                )
+
+            logger.info(f"Request: {request}")
+            generator = await self.openai_serving.create_completion(
+                request, raw_request
+            )
+            if isinstance(generator, ErrorResponse):
+                return JSONResponse(
+                    content=generator.model_dump(), status_code=generator.code
+                )
+            if request.stream:
+                return StreamingResponse(content=generator, media_type="text/event-stream")
+            else:
+                assert isinstance(generator, CompletionResponse)
+                return JSONResponse(content=generator.model_dump())
+
+        @app.post("/v1/chat/completions")
+        async def create_chat_completion(
+                self, request: ChatCompletionRequest, raw_request: Request
+        ):
+            if not self.openai_serving_chat:
+                model_config = await self.engine.get_model_config()
+                base_model_paths = [BaseModelPath(name=self.engine_args.model, model_path=self.engine_args.model)]
+                openai_serving_models = OpenAIServingModels(
+                    engine_client=self.engine,
+                    model_config=model_config,
+                    base_model_paths=base_model_paths,
+                )
+                self.openai_serving_chat = OpenAIServingChat(
+                    engine_client=self.engine,
+                    model_config=model_config,
+                    models=openai_serving_models,
+                    response_role=self.response_role,
+                    request_logger=None,
+                    chat_template=self.chat_template,
+                    chat_template_content_format="auto"
+                )
+            logger.info(f"Request: {request}")
+            generator = await self.openai_serving_chat.create_chat_completion(
+                request, raw_request
+            )
+            if isinstance(generator, ErrorResponse):
+                return JSONResponse(
+                    content=generator.model_dump(), status_code=generator.code
+                )
+            if request.stream:
+                return StreamingResponse(content=generator, media_type="text/event-stream")
+            else:
+                assert isinstance(generator, ChatCompletionResponse)
+                return JSONResponse(content=generator.model_dump())
+
+
+    deployment = VLLMDeployment.bind()

--- a/blueprints/inference/neuron/ray-vllm/ray-vllm-deployment.yaml
+++ b/blueprints/inference/neuron/ray-vllm/ray-vllm-deployment.yaml
@@ -1,0 +1,216 @@
+apiVersion: ray.io/v1
+kind: RayService
+metadata:
+  name: $SERVICE_NAME
+  namespace: $SERVICE_NAMESPACE
+spec:
+  deploymentUnhealthySecondThreshold: 900
+  rayClusterConfig:
+    headGroupSpec:
+      headService:
+        metadata:
+          name: $SERVICE_NAME
+          namespace: $SERVICE_NAMESPACE
+      rayStartParams:
+        dashboard-host: 0.0.0.0
+        num-cpus: '0'
+      template:
+        spec:
+          containers:
+            - env:
+                - name: VLLM_LOGGING_LEVEL
+                  value: DEBUG
+                - name: HUGGING_FACE_HUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      key: token
+                      name: hf-token
+                - name: LD_LIBRARY_PATH
+                  value: /home/ray/anaconda3/lib
+                - name: RAY_GRAFANA_HOST
+                  value: >-
+                    http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local
+                - name: RAY_PROMETHEUS_HOST
+                  value: >-
+                    http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+                - name: RAY_GRAFANA_IFRAME_HOST
+                  value: http://localhost:3000
+              image: 975050295866.dkr.ecr.us-west-2.amazonaws.com/ray-vllm-neuron:2.47.0-0.9.1
+              imagePullPolicy: Always
+              workingDir: /home/ray
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                      - /bin/sh
+                      - '-c'
+                      - ray stop
+              name: head
+              ports:
+                - containerPort: 6379
+                  name: gcs
+                  protocol: TCP
+                - containerPort: 8265
+                  name: dashboard
+                  protocol: TCP
+                - containerPort: 10001
+                  name: client
+                  protocol: TCP
+                - containerPort: 8000
+                  name: serve
+                  protocol: TCP
+              resources:
+                limits:
+                  cpu: 4
+                  memory: 20Gi
+                requests:
+                  cpu: 4
+                  memory: 20Gi
+              volumeMounts:
+                - mountPath: /tmp/ray
+                  name: ray-logs
+                - mountPath: /home/ray/vllm_serve.py
+                  subPath: vllm_serve.py
+                  name: vllm-script
+            - name: fluentbit
+              image: fluent/fluent-bit:3.2.2
+              # Get Kubernetes metadata via downward API
+              env:
+                - name: POD_LABELS
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.labels['ray.io/cluster']
+              # These resource requests for Fluent Bit should be sufficient in production.
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+              volumeMounts:
+                - mountPath: /tmp/ray
+                  name: ray-logs
+                - mountPath: /fluent-bit/etc/fluent-bit.conf
+                  subPath: fluent-bit.conf
+                  name: fluentbit-config
+          volumes:
+            - emptyDir: {}
+              name: ray-logs
+            - configMap:
+                items:
+                  - key: vllm_serve.py
+                    path: vllm_serve.py
+                name: ray-vllm-serve
+              name: vllm-script
+            - name: fluentbit-config
+              configMap:
+                name: fluentbit-config
+    rayVersion: 2.47.0
+    workerGroupSpecs:
+      - groupName: worker
+        maxReplicas: $MAX_REPLICAS
+        minReplicas: $MIN_REPLICAS
+        numOfHosts: 1
+        rayStartParams:
+          # This setting is critical for inf2/Trn1 node autoscaling with RayServe
+          resources: '"{\"neuron_cores\": 2}"'
+        replicas: 1
+        template:
+          spec:
+            containers:
+              - env:
+                  - name: LD_LIBRARY_PATH
+                    value: /home/ray/anaconda3/lib
+                  - name: VLLM_PORT
+                    value: '8004'
+                  - name: VLLM_LOGGING_LEVEL
+                    value: DEBUG
+                  - name: HUGGING_FACE_HUB_TOKEN
+                    valueFrom:
+                      secretKeyRef:
+                        key: token
+                        name: hf-token
+                  - name: MODEL_ID
+                    value: "$MODEL_ID"
+                  - name: GPU_MEMORY_UTILIZATION
+                    value: "$GPU_MEMORY_UTILIZATION"
+                  - name: MAX_MODEL_LEN
+                    value: "$MAX_MODEL_LEN"
+                  - name: MAX_NUM_SEQ
+                    value: "$MAX_NUM_SEQ"
+                  - name: MAX_NUM_BATCHED_TOKENS
+                    value: "$MAX_NUM_BATCHED_TOKENS"
+                  - name: TOKENIZER_POOL_SIZE
+                    value: "$TOKENIZER_POOL_SIZE"
+                  - name: MAX_PARALLEL_LOADING_WORKERS
+                    value: "$MAX_PARALLEL_LOADING_WORKERS"
+                  - name: PIPELINE_PARALLEL_SIZE
+                    value: "$PIPELINE_PARALLEL_SIZE"
+                  - name: TENSOR_PARALLEL_SIZE
+                    value: "$TENSOR_PARALLEL_SIZE"
+                  - name: ENABLE_PREFIX_CACHING
+                    value: "$ENABLE_PREFIX_CACHING"
+                  - name: NUM_GPUS
+                    value: "$NUM_GPUS"
+                  - name: NEURON_CC_FLAGS
+                    value: "-O1"
+                workingDir: /home/ray
+                image: 975050295866.dkr.ecr.us-west-2.amazonaws.com/ray-vllm-neuron:2.47.0-0.9.1
+                imagePullPolicy: IfNotPresent
+                lifecycle:
+                  preStop:
+                    exec:
+                      command:
+                        - /bin/sh
+                        - '-c'
+                        - ray stop
+                name: worker
+                resources:
+                  limits:
+                    aws.amazon.com/neuron: $NUM_GPUS
+                  requests:
+                    aws.amazon.com/neuron: $NUM_GPUS
+                    memory: 100Gi
+                volumeMounts:
+                  - mountPath: /tmp/ray
+                    name: ray-logs
+              - name: fluentbit
+                image: fluent/fluent-bit:3.2.2
+                env:
+                  - name: POD_LABELS
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.labels['ray.io/cluster']
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 128Mi
+                  limits:
+                    cpu: 100m
+                    memory: 128Mi
+                volumeMounts:
+                  - mountPath: /tmp/ray
+                    name: ray-logs
+                  - mountPath: /fluent-bit/etc/fluent-bit.conf
+                    subPath: fluent-bit.conf
+                    name: fluentbit-config
+            volumes:
+              - emptyDir: {}
+                name: ray-logs
+              - name: fluentbit-config
+                configMap:
+                  name: fluentbit-config
+            tolerations:
+              - key: "aws.amazon.com/neuron"
+                operator: "Exists"
+                effect: "NoSchedule"
+  serveConfigV2: |
+    applications:
+      - name: serve
+        import_path: vllm_serve:deployment
+        deployments:
+          - name: serve
+            ray_actor_options:
+              resources: {"neuron_cores": $TENSOR_PARALLEL_SIZE}
+  serviceUnhealthySecondThreshold: 900

--- a/blueprints/inference/neuron/ray-vllm/template.sh
+++ b/blueprints/inference/neuron/ray-vllm/template.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [[ $# -eq 0 ]] ; then
+    echo 'No model file supplied'
+    exit 1
+fi
+
+
+# Load the variables
+set -a  # Mark all variables for export
+source $1 # Read the input variables from the environment file
+set +a  # Stop auto-exporting
+
+PYTHON_VERSION=${PYTHON_VERSION//.}
+# Perform the substitution
+envsubst < ray-vllm-deployment.yaml > $SERVICE_NAME-$(date +%F_%H_%M_%S).yaml

--- a/blueprints/inference/neuron/vllm/llama-3.1-8b.env
+++ b/blueprints/inference/neuron/vllm/llama-3.1-8b.env
@@ -1,0 +1,21 @@
+# Kubernetes
+SERVICE_NAME=llama-31-8b-vllm-nrn # must start with lowercase, contain only alphanumeric or dashes and end in with alphanumeric
+SERVICE_NAMESPACE=default
+
+# Infrastructure
+VLLM_VERSION=0.9.1
+# 1 Neuron device
+NUM_GPUS=1
+
+# Model Specific
+MODEL_ID=meta-llama/Llama-3.1-8B-Instruct
+GPU_MEMORY_UTILIZATION="0.8"
+MAX_MODEL_LEN=1024
+MAX_NUM_SEQ=1
+MAX_NUM_BATCHED_TOKENS=1024
+TOKENIZER_POOL_SIZE=4
+MAX_PARALLEL_LOADING_WORKERS=2
+PIPELINE_PARALLEL_SIZE=1
+# Neuron has 2 cores per device
+TENSOR_PARALLEL_SIZE=2
+ENABLE_PREFIX_CACHING=false

--- a/blueprints/inference/neuron/vllm/template.sh
+++ b/blueprints/inference/neuron/vllm/template.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ $# -eq 0 ]] ; then
+    echo 'No model file supplied'
+    exit 1
+fi
+
+# Load the variables
+set -a  # Mark all variables for export
+source $1 # Read the input variables from the environment file
+set +a  # Stop auto-exporting
+
+# Perform the substitution
+envsubst < vllm-deployment.yaml > $SERVICE_NAME-$(date +%F_%H_%M_%S).yaml

--- a/blueprints/inference/neuron/vllm/vllm-configmap.yaml
+++ b/blueprints/inference/neuron/vllm/vllm-configmap.yaml
@@ -1,0 +1,185 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vllm-serve
+  namespace: default
+data:
+  vllm_serve.py: |
+    import re
+    from typing import Optional
+    from fastapi import FastAPI
+    from prometheus_client import make_asgi_app
+    from starlette.routing import Mount
+    from vllm.engine.arg_utils import AsyncEngineArgs
+    from vllm.engine.async_llm_engine import AsyncLLMEngine
+    from vllm.entrypoints.openai.serving_models import BaseModelPath,OpenAIServingModels
+    from starlette.requests import Request
+    from starlette.responses import StreamingResponse, JSONResponse
+    import os
+    import logging
+    from vllm.entrypoints.openai.serving_chat import OpenAIServingChat
+    from vllm.entrypoints.openai.serving_completion import OpenAIServingCompletion
+    from vllm.transformers_utils.config import get_config
+    from huggingface_hub import login
+    from vllm.entrypoints.openai.protocol import (
+        CompletionRequest,
+        CompletionResponse,
+        ChatCompletionRequest,
+        ChatCompletionResponse,
+        ErrorResponse,
+    )
+    import uvicorn
+    logger = logging.getLogger("vllm")
+    app = FastAPI()
+    deployment = None
+
+    def get_model_config(model_path: str) -> dict:
+        try:
+            config = get_config(model_path)
+            return {
+                "architecture": config.architectures[0] if config.architectures else None,
+                "vocab_size": config.vocab_size,
+                "hidden_size": config.hidden_size,
+                "num_hidden_layers": config.num_hidden_layers,
+                "num_attention_heads": config.num_attention_heads,
+            }
+        except Exception as e:
+            logger.warning(f"Error reading model config: {e}")
+            return {}
+
+    class VLLMDeployment:
+        def __init__(self, response_role: str = "assistant",
+                     chat_template: Optional[str] = None, **kwargs):
+            route = Mount("/metrics", make_asgi_app())
+            route.path_regex = re.compile('^/metrics(?P<path>.*)$')
+            app.routes.append(route)
+
+            hf_token = os.getenv("HUGGING_FACE_HUB_TOKEN")
+            if not hf_token:
+                raise ValueError("HUGGING_FACE_HUB_TOKEN environment variable is not set")
+            login(token=hf_token)
+            logger.info("Successfully logged in to Hugging Face Hub")
+
+            self.engine_args = AsyncEngineArgs(
+                model=os.getenv("MODEL_ID", "NousResearch/Llama-3.2-1B"),
+                dtype="auto",
+                gpu_memory_utilization=float(os.getenv("GPU_MEMORY_UTILIZATION", "0.8")),
+                max_model_len=int(os.getenv("MAX_MODEL_LEN", "8192")),
+                max_num_seqs=int(os.getenv("MAX_NUM_SEQ", "4")),
+                max_num_batched_tokens=int(os.getenv("MAX_NUM_BATCHED_TOKENS", "8192")),
+                trust_remote_code=True,
+                enable_chunked_prefill=False,
+                tokenizer_pool_size=int(os.getenv("TOKENIZER_POOL_SIZE", "4")),
+                pipeline_parallel_size=int(os.getenv("PIPELINE_PARALLEL_SIZE", "1")),
+                tensor_parallel_size=int(os.getenv("TENSOR_PARALLEL_SIZE", "1")),
+                enable_prefix_caching=bool(os.getenv("ENABLE_PREFIX_CACHING", "true")),
+                enforce_eager=True,
+            )
+            self.openai_serving_chat = None
+            self.openai_serving = None
+            self.response_role = response_role
+            self.chat_template = chat_template
+            self.engine = AsyncLLMEngine.from_engine_args(self.engine_args)
+            self.max_model_len = self.engine_args.max_model_len
+            logger.info(f"VLLM Engine initialized with max_model_len: {self.max_model_len}")
+
+        async def get_models(self):
+            model_info = {
+                "object": "list",
+                "data": [
+                    {
+                        "id": self.engine_args.model,
+                        "object": "model",
+                        "owned_by": "organization",
+                        "permission": []
+                    }
+                ]
+            }
+            return JSONResponse(content=model_info)
+
+        async def create_completion(self, request: CompletionRequest, raw_request: Request):
+            if not self.openai_serving:
+                model_config = await self.engine.get_model_config()
+                base_model_paths = [BaseModelPath(name=self.engine_args.model, model_path=self.engine_args.model)]
+                openai_serving_models = OpenAIServingModels(
+                    engine_client=self.engine,
+                    model_config=model_config,
+                    base_model_paths=base_model_paths,
+                )
+                self.openai_serving = OpenAIServingCompletion(
+                    engine_client=self.engine,
+                    model_config=model_config,
+                    models=openai_serving_models,
+                    request_logger=None
+                )
+            logger.info(f"Request: {request}")
+            generator = await self.openai_serving.create_completion(
+                request, raw_request
+            )
+            if isinstance(generator, ErrorResponse):
+                return JSONResponse(
+                    content=generator.model_dump(), status_code=generator.code
+                )
+            if request.stream:
+                return StreamingResponse(content=generator, media_type="text/event-stream")
+            else:
+                assert isinstance(generator, CompletionResponse)
+                return JSONResponse(content=generator.model_dump())
+
+        async def create_chat_completion(self, request: ChatCompletionRequest, raw_request: Request):
+            if not self.openai_serving_chat:
+                model_config = await self.engine.get_model_config()
+                base_model_paths = [BaseModelPath(name=self.engine_args.model, model_path=self.engine_args.model)]
+                openai_serving_models = OpenAIServingModels(
+                    engine_client=self.engine,
+                    model_config=model_config,
+                    base_model_paths=base_model_paths,
+                )
+                self.openai_serving_chat = OpenAIServingChat(
+                    engine_client=self.engine,
+                    model_config=model_config,
+                    models=openai_serving_models,
+                    response_role=self.response_role,
+                    request_logger=None,
+                    chat_template=self.chat_template,
+                    chat_template_content_format="auto"
+                )
+            logger.info(f"Request: {request}")
+            generator = await self.openai_serving_chat.create_chat_completion(
+                request, raw_request
+            )
+            if isinstance(generator, ErrorResponse):
+                return JSONResponse(
+                    content=generator.model_dump(), status_code=generator.code
+                )
+            if request.stream:
+                return StreamingResponse(content=generator, media_type="text/event-stream")
+            else:
+                assert isinstance(generator, ChatCompletionResponse)
+                return JSONResponse(content=generator.model_dump())
+
+    def create_deployment():
+        global deployment
+        deployment = VLLMDeployment()
+        return deployment
+
+    @app.on_event("startup")
+    async def startup_event():
+        create_deployment()
+
+    @app.get("/v1/models")
+    async def get_models():
+        return await deployment.get_models()
+
+    @app.post("/v1/completions")
+    async def create_completion(request: CompletionRequest, raw_request:
+    Request):
+        return await deployment.create_completion(request, raw_request)
+
+    @app.post("/v1/chat/completions")
+    async def create_chat_completion(request: ChatCompletionRequest,
+                                     raw_request: Request):
+        return await deployment.create_chat_completion(request, raw_request)
+
+    if __name__ == "__main__":
+        uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/blueprints/inference/neuron/vllm/vllm-deployment.yaml
+++ b/blueprints/inference/neuron/vllm/vllm-deployment.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: $SERVICE_NAME
+  namespace: $SERVICE_NAMESPACE
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: $SERVICE_NAME
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: $SERVICE_NAME
+    spec:
+      containers:
+        - name: vllm
+          image: public.ecr.aws/q9t5s3a7/vllm-neuron-release-repo:v$VLLM_VERSION
+          command: ["/bin/sh", "-c"]
+          args: [
+            "python3 /vllm-workspace/vllm_serve.py"
+          ]
+          env:
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token
+                  key: token
+            - name: MODEL_ID
+              value: "$MODEL_ID"
+            - name: GPU_MEMORY_UTILIZATION
+              value: "$GPU_MEMORY_UTILIZATION"
+            - name: MAX_MODEL_LEN
+              value: "$MAX_MODEL_LEN"
+            - name: MAX_NUM_SEQ
+              value: "$MAX_NUM_SEQ"
+            - name: MAX_NUM_BATCHED_TOKENS
+              value: "$MAX_NUM_BATCHED_TOKENS"
+            - name: TOKENIZER_POOL_SIZE
+              value: "$TOKENIZER_POOL_SIZE"
+            - name: MAX_PARALLEL_LOADING_WORKERS
+              value: "$MAX_PARALLEL_LOADING_WORKERS"
+            - name: PIPELINE_PARALLEL_SIZE
+              value: "$PIPELINE_PARALLEL_SIZE"
+            - name: TENSOR_PARALLEL_SIZE
+              value: "$TENSOR_PARALLEL_SIZE"
+            - name: ENABLE_PREFIX_CACHING
+              value: "$ENABLE_PREFIX_CACHING"
+            - name: NUM_GPUS
+              value: "$NUM_GPUS"
+          ports:
+            - containerPort: 8000
+          resources:
+            limits:
+              aws.amazon.com/neuron: $NUM_GPUS
+            requests:
+              aws.amazon.com/neuron: $NUM_GPUS
+              memory: 100Gi
+          volumeMounts:
+            - mountPath: /vllm-workspace/vllm_serve.py
+              subPath: vllm_serve.py
+              name: vllm-script
+      tolerations:
+        - key: "aws.amazon.com/neuron"
+          operator: "Exists"
+          effect: "NoSchedule"
+      volumes:
+        - configMap:
+            items:
+              - key: vllm_serve.py
+                path: vllm_serve.py
+            name: vllm-serve
+          name: vllm-script
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: $SERVICE_NAME
+  namespace: $SERVICE_NAMESPACE
+spec:
+  selector:
+    app.kubernetes.io/name: $SERVICE_NAME
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000
+  type: ClusterIP


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/ai-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

This PR starts to standardize vLLM with/without Ray deployments on either neuron or GPU hardware. 

### Motivation

Currently, adding a new blueprint requires finding a similar one to copy/paste and edit some values. This creates difficulty in maintaining the changes across versions as well creating divergence among the different models. This PR aims to address a few issues:

1) Creating consistent, OpenAI based model endpoints. 
2) Creating reusable deployments
3) Updating vLLM and Ray to the newest versions
4) Creating a foundation for future work

### Questions

#### Aren't the configmaps for vLLM only deploments on neuron/gpu and ray+vllm deployments on neuron/gpu the same?
Yes! They need to be de-duplicated, but this illustrates the consistency we now have being hardware agnostic. 

#### Aren't the models also duplicated?
Yes, that too. The intention now is to further consolidate the files

#### Why do I have to create an image for ray + vllm on neuron?
Unfortunately, as there is not yet a neuron vLLM wheel and there is not yet a Ray image published with that wheel, we have to create our own docker image. An example one is included for the latest version of Ray and the latest version of vLLM. 

#### There are some parameters I want to use that aren't exposed
Please let us know which ones, this is only a sample to create the initial deployment, but we will add more of them. 

#### Can I deploy these as-is to production?
It's not recommended. These are here to highlight a story: how do you test accelerators, frameworks, and start thinking about scaling and model configurations. The content for these questions will come in a future PR, but this is to help answer some of these questions. Some issues with this deployment:
1) The Ray python environment is built at runtime, this is not optimal
2) Neuron models are compiled at runtime, this is not optimal
3) Weights are copied from Hugging Face at runtime, this is not optimal. 

This PR aims to tackle the experimentation phase of deploying LLMs, we will bring more content on production in a future PR. 

### How to use
Under `blueprints/inference`, there are folders for either `gpu` or `neuron`. Under these folders are either `ray-vllm` or `vllm`. If you want to deploy ray with vllm on gpu, you would use `blueprints/inference/gpu/ray-vllm` and if you wanted to use vllm on neuron, you would use `blueprints/inference/neuron/vllm`. Each of these folders has a model deployment file that ends in `.env`. Let's take an example of ray with vllm on GPU:

```
cd blueprints/inference/gpu/ray-vllm`
kubectl apply -f ray-vllm-configmap.yaml
kubectl apply -f fluentbit-configmap.yaml
./template llama-3.2-1b.env
```
This will create two generic configmaps that are necessary for the ray deployment as well as generate a deployment for the llama model. The file will look something like `llama-3.2-1B-$DATE`. Where $DATE is the date and time the file was generated. You can then `kubectl apply -f $FILENAME`

Once the service is running, you will need to portforward the `serve` port:
```
kubectl port-forward svc/llama-32-1b-ray-head-svc 8000
```

This will forward the serve port to your local machine. You can then check `http://localhost:8000/v1/models` to ensure the model is deployed. 

Finally, you can use a simple client to query the model:
```python
from openai import OpenAI

model = "NousResearch/Llama-3.2-1B" # model name in org/model format
port = 8000 # port number being forwarded
prompt = "Hello" # prompt
client = OpenAI(
    base_url=f"http://localhost:{port}/v1",
    api_key="token",
)

# Completion
response = client.completions.create(
    model=model,
    prompt=prompt
)
print(response.choices[0].text)
```

Depending on if you're testing a chat or completion model, you will either need to use: 
```python
# Chat Completion
response = client.chat.completions.create(
    model=model,
    messages=[
        {"role": "user", "content": f"{prompt}"}
    ]
)
print(response.choices[0].message)

# Completions

response = client.completions.create(
    model=model,
    prompt=prompt
)
print(response.choices[0].text)
```

### Observability
If you've deployed the `ai-ml-observability-reference-architecture` addon, you should see these models in the dashboard, they follow the correct instrumentation to appear there. Follow the [guide](https://awslabs.github.io/ai-on-eks/docs/bestpractices/observability) to access them. 

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
