### PR TITLE
 Fix Helm provider version constraint

### DIFF
--- a/infra/base/terraform/versions.tf
+++ b/infra/base/terraform/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.4.1"
+      version = ">= 2.4.1, < 3.0.0"
     }
     http = {
       source  = "hashicorp/http"


### PR DESCRIPTION
## What does this PR do?
  This PR adds an upper bound constraint to the Helm provider version to prevent compatibility issues with major version upgrades that broke the infrastructure 5 days ago.

  ## Motivation
  On June 18, 2025 (5 days ago), the Helm provider received a major update in the Terraform registry. Since then, our infrastructure deployments have been failing due to breaking changes introduced in the new version. The
  previous constraint `>= 2.4.1` was too permissive and automatically pulled the incompatible newer version. Adding the upper bound `< 3.0.0` ensures compatibility and prevents these deployment failures.

  ## Impact
  - **Before**: Deployments failing for 5 days due to automatic major version upgrades
  - **After**: Stable deployments with controlled version constraints

  ## Testing
  - [x] Yes, I have tested the PR using my local account setup
  - [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
  - [ ] Mandatory for new blueprints. Yes, I have updated the website/docs or website/blog section for this feature
  - [x] Yes, I ran pre-commit run -a with this PR. [Link for installing pre-commit locally](https://pre-commit.com/#install)

  ## For Moderators
  - [ ] E2E Test successfully complete before merge?

  ## Additional Notes
  **Changes made:**
  - `infra/base/terraform/versions.tf`: Added upper bound `< 3.0.0` to Helm provider version constraint (changed from `>= 2.4.1` to `>= 2.4.1, < 3.0.0`)

  **Root Cause:**
  The Terraform Helm provider registry was updated 5 days ago with breaking changes. Without version constraints, Terraform automatically picked up the latest incompatible version, causing deployment failures across all
  environments.

  **Solution:**
  This change ensures version stability and prevents automatic major version upgrades that could introduce breaking changes. The constraint allows patch and minor updates within the 2.x series while blocking potentially
  breaking 3.x versions.