### PR TITLE
Add autoscaling config to inference charts

### DIFF
--- a/blueprints/inference/inference-charts/README.md
+++ b/blueprints/inference/inference-charts/README.md
@@ -120,12 +120,6 @@ inference:
     idleTimeoutSeconds: 120  # Wait 2 minutes before scaling down
 ```
 
-### Deploy with Autoscaling
-
-```bash
-helm install ray-autoscale-inference ./inference-charts --values values-ray-vllm-autoscaling.yaml
-```
-
 ## Examples
 
 ### Deploy GPU Ray-VLLM with DeepSeek R1 Distill Llama 8B model

--- a/blueprints/inference/inference-charts/templates/ray-vllm-configmap.yaml
+++ b/blueprints/inference/inference-charts/templates/ray-vllm-configmap.yaml
@@ -58,9 +58,7 @@ data:
             return {}
 
 
-    @serve.deployment(name="serve",
-                      autoscaling_config={"min_replicas": 1, "max_replicas": 2},
-                      )
+    @serve.deployment(name="serve")
     @serve.ingress(app)
     class VLLMDeployment:
         def __init__(self, response_role: str = "assistant",

--- a/blueprints/inference/inference-charts/templates/ray-vllm-deployment.yaml
+++ b/blueprints/inference/inference-charts/templates/ray-vllm-deployment.yaml
@@ -7,6 +7,14 @@ metadata:
 spec:
   deploymentUnhealthySecondThreshold: 900
   rayClusterConfig:
+    {{- if .Values.inference.modelServer.deployment.autoscaling.enabled }}
+    enableInTreeAutoscaling: true
+    autoscalerOptions:
+      upscalingSpeed: {{ .Values.inference.modelServer.deployment.autoscaling.upscalingSpeed | default 1.0 }}
+      downscalingSpeed: {{ .Values.inference.modelServer.deployment.autoscaling.downscalingSpeed | default 1.0 }}
+      idleTimeoutSeconds: {{ .Values.inference.modelServer.deployment.autoscaling.idleTimeoutSeconds | default 60 }}
+      resources: {}
+  {{- else }}
     headGroupSpec:
       headService:
         metadata:
@@ -100,9 +108,9 @@ spec:
       - groupName: worker
         maxReplicas: {{ .Values.inference.modelServer.deployment.maxReplicas }}
         minReplicas: {{ .Values.inference.modelServer.deployment.minReplicas }}
+          replicas: {{ .Values.inference.modelServer.deployment.replicas }}
         numOfHosts: 1
         rayStartParams: {}
-        replicas: {{ .Values.inference.modelServer.deployment.replicas }}
         template:
           spec:
             {{- if eq .Values.inference.accelerator "neuron" }}

--- a/blueprints/inference/inference-charts/templates/ray-vllm-deployment.yaml
+++ b/blueprints/inference/inference-charts/templates/ray-vllm-deployment.yaml
@@ -7,14 +7,13 @@ metadata:
 spec:
   deploymentUnhealthySecondThreshold: 900
   rayClusterConfig:
-    {{- if .Values.inference.modelServer.deployment.autoscaling.enabled }}
+    {{- if .Values.inference.rayOptions.autoscaling.enabled }}
     enableInTreeAutoscaling: true
     autoscalerOptions:
-      upscalingSpeed: {{ .Values.inference.modelServer.deployment.autoscaling.upscalingSpeed | default 1.0 }}
-      downscalingSpeed: {{ .Values.inference.modelServer.deployment.autoscaling.downscalingSpeed | default 1.0 }}
-      idleTimeoutSeconds: {{ .Values.inference.modelServer.deployment.autoscaling.idleTimeoutSeconds | default 60 }}
+      upscalingMode: {{ .Values.inference.rayOptions.autoscaling.upscalingMode }}
+      idleTimeoutSeconds: {{ .Values.inference.rayOptions.autoscaling.idleTimeoutSeconds }}
       resources: {}
-  {{- else }}
+    {{- end }}
     headGroupSpec:
       headService:
         metadata:
@@ -35,11 +34,11 @@ spec:
                 - name: LD_LIBRARY_PATH
                   value: /home/ray/anaconda3/lib
                 - name: RAY_GRAFANA_HOST
-                  value: {{ .Values.inference.observability.rayGrafanaHost }}
+                  value: {{ .Values.inference.rayOptions.observability.rayGrafanaHost }}
                 - name: RAY_PROMETHEUS_HOST
-                  value: {{ .Values.inference.observability.rayPrometheusHost }}
+                  value: {{ .Values.inference.rayOptions.observability.rayPrometheusHost }}
                 - name: RAY_GRAFANA_IFRAME_HOST
-                  value: {{ .Values.inference.observability.rayGrafanaIframeHost }}
+                  value: {{ .Values.inference.rayOptions.observability.rayGrafanaIframeHost }}
               image: "{{ .Values.inference.modelServer.image.repository }}:{{ .Values.inference.modelServer.image.tag }}"
               imagePullPolicy: {{ .Values.global.image.pullPolicy }}
               lifecycle:
@@ -103,12 +102,12 @@ spec:
             - name: fluentbit-config
               configMap:
                 name: fluentbit-config
-    rayVersion: {{ .Values.inference.modelServer.rayVersion }}
+    rayVersion: {{ .Values.inference.rayOptions.rayVersion }}
     workerGroupSpecs:
       - groupName: worker
         maxReplicas: {{ .Values.inference.modelServer.deployment.maxReplicas }}
         minReplicas: {{ .Values.inference.modelServer.deployment.minReplicas }}
-          replicas: {{ .Values.inference.modelServer.deployment.replicas }}
+        replicas: {{ .Values.inference.modelServer.deployment.replicas }}
         numOfHosts: 1
         rayStartParams: {}
         template:
@@ -211,5 +210,8 @@ spec:
               {{- else }}
               resources: {"neuron_cores": {{ mul .Values.modelParameters.numGpus 2 }}}
               {{- end }}
+            autoscaling_config:
+              min_replicas: {{ .Values.inference.rayOptions.autoscaling.actorAutoscaling.minActors }}
+              max_replicas: {{ .Values.inference.rayOptions.autoscaling.actorAutoscaling.maxActors }}
   serviceUnhealthySecondThreshold: 900
 {{- end }}

--- a/blueprints/inference/inference-charts/values-deepseek-r1-distill-llama-8b-ray-vllm-gpu.yaml
+++ b/blueprints/inference/inference-charts/values-deepseek-r1-distill-llama-8b-ray-vllm-gpu.yaml
@@ -17,8 +17,9 @@ inference:
   accelerator: gpu
   framework: rayVllm
 
-  modelServer:
+  rayOptions:
     rayVersion: 2.47.0
+  modelServer:
     vllmVersion: 0.9.1
     pythonVersion: 3.11
     image:

--- a/blueprints/inference/inference-charts/values-llama-32-1b-ray-vllm.yaml
+++ b/blueprints/inference/inference-charts/values-llama-32-1b-ray-vllm.yaml
@@ -17,8 +17,10 @@ inference:
   accelerator: gpu
   framework: rayVllm
 
-  modelServer:
+  rayOptions:
     rayVersion: 2.47.0
+
+  modelServer:
     vllmVersion: 0.9.1
     pythonVersion: 3.11
     image:

--- a/blueprints/inference/inference-charts/values-mistral-small-24b-ray-vllm.yaml
+++ b/blueprints/inference/inference-charts/values-mistral-small-24b-ray-vllm.yaml
@@ -17,8 +17,10 @@ inference:
   accelerator: gpu
   framework: rayVllm
 
-  modelServer:
+  rayOptions:
     rayVersion: 2.46.0
+
+  modelServer:
     vllmVersion: 0.9.0
     pythonVersion: 3.11
     image:

--- a/blueprints/inference/inference-charts/values.yaml
+++ b/blueprints/inference/inference-charts/values.yaml
@@ -55,19 +55,28 @@ inference:
   # Framework type: vllm or rayVllm
   framework: vllm
 
-  modelServer:
+  #Ray Specific Options
+  rayOptions:
     rayVersion: 2.47.0
+    # Ray native autoscaling configuration
+    autoscaling:
+      enabled: false
+      # Ray autoscaler specific settings
+      upscalingMode: "Default"
+      idleTimeoutSeconds: 60  # How long to wait before scaling down idle nodes
+      actorAutoscaling:
+        minActors: 1
+        maxActors: 1
+    observability:
+      rayPrometheusHost: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+      rayGrafanaHost: http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local
+      rayGrafanaIframeHost: http://localhost:3000
+
+  modelServer:
     image:
       repository: vllm/vllm-openai
       tag: latest
     deployment:
-      # Ray native autoscaling configuration
-      autoscaling:
-        enabled: false
-        # Ray autoscaler specific settings
-        upscalingSpeed: 1.0  # How aggressively to scale up (1.0 = normal, >1.0 = more aggressive)
-        downscalingSpeed: 1.0  # How aggressively to scale down (1.0 = normal, >1.0 = more aggressive)
-        idleTimeoutSeconds: 60  # How long to wait before scaling down idle nodes
       replicas: 1
       maxReplicas: 2
       minReplicas: 1
@@ -84,10 +93,6 @@ inference:
             aws.amazon.com/neuron: 1
     env: {}
 
-  observability:
-    rayPrometheusHost: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
-    rayGrafanaHost: http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local
-    rayGrafanaIframeHost: http://localhost:3000
 
 # Service configuration
 service:

--- a/blueprints/inference/inference-charts/values.yaml
+++ b/blueprints/inference/inference-charts/values.yaml
@@ -61,6 +61,13 @@ inference:
       repository: vllm/vllm-openai
       tag: latest
     deployment:
+      # Ray native autoscaling configuration
+      autoscaling:
+        enabled: false
+        # Ray autoscaler specific settings
+        upscalingSpeed: 1.0  # How aggressively to scale up (1.0 = normal, >1.0 = more aggressive)
+        downscalingSpeed: 1.0  # How aggressively to scale down (1.0 = normal, >1.0 = more aggressive)
+        idleTimeoutSeconds: 60  # How long to wait before scaling down idle nodes
       replicas: 1
       maxReplicas: 2
       minReplicas: 1


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/ai-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

Adds autoscaling config to inference-charts

### Motivation

This allows using ray autoscaling with the inference-charts. It defaults to 1 actor and 1 replica unless otherwise specified. 

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
