### PR TITLE
Update Infrastructure and Blueprint docs to use blueprint.tfvars

### DIFF
--- a/website/docs/blueprints/inference/GPUs/nvidia-nim-llama3.md
+++ b/website/docs/blueprints/inference/GPUs/nvidia-nim-llama3.md
@@ -120,14 +120,14 @@ export TF_VAR_ngc_api_key=<replace-with-your-NGC-API-KEY>
 
 **2. Installation**
 
-Important Note: Ensure that you update the region in the variables.tf file before deploying the blueprint. Additionally, confirm that your local region setting matches the specified region to prevent any discrepancies. For example, set your `export AWS_DEFAULT_REGION="<REGION>"` to the desired region:
+Important Note: Ensure that you update the region in the `blueprint.tfvars` file before deploying the blueprint. Additionally, confirm that your local region setting matches the specified region to prevent any discrepancies. For example, set your `export AWS_DEFAULT_REGION="<REGION>"` to the desired region:
 
 Run the installation script:
 
 :::info
 
 
-This pattern deploys a model called `nvcr.io/nim/meta/llama3-8b-instruct`. You can modify the `nim_models` variable in the `variables.tf` file to add more models. Multiple models can be deployed simultaneously using this pattern.
+This pattern deploys a model called `nvcr.io/nim/meta/llama3-8b-instruct`. You can modify the `nim_models` variable in the `blueprint.tfvars` file to add more models. Multiple models can be deployed simultaneously using this pattern.
 :::
 
 :::caution

--- a/website/docs/blueprints/inference/GPUs/ray-vllm-deepseek.md
+++ b/website/docs/blueprints/inference/GPUs/ray-vllm-deepseek.md
@@ -65,7 +65,7 @@ git clone https://github.com/awslabs/ai-on-eks.git
 
 **Important Note:**
 
-**Step1**: Ensure that you update the region in the `variables.tf` file before deploying the blueprint.
+**Step1**: Ensure that you update the region in the `blueprint.tfvars` file before deploying the blueprint.
 Additionally, confirm that your local region setting matches the specified region to prevent any discrepancies.
 
 For example, set your `export AWS_DEFAULT_REGION="<REGION>"` to the desired region:

--- a/website/docs/blueprints/inference/GPUs/stablediffusion-gpus.md
+++ b/website/docs/blueprints/inference/GPUs/stablediffusion-gpus.md
@@ -68,7 +68,7 @@ cd ai-on-eks/infra/jark-stack/ && chmod +x install.sh
 
 Navigate into one of the example directories and run `install.sh` script
 
-**Important Note:** Ensure that you update the region in the `variables.tf` file before deploying the blueprint.
+**Important Note:** Ensure that you update the region in the `blueprint.tfvars` file before deploying the blueprint.
 Additionally, confirm that your local region setting matches the specified region to prevent any discrepancies.
 For example, set your `export AWS_DEFAULT_REGION="<REGION>"` to the desired region:
 

--- a/website/docs/blueprints/inference/GPUs/vLLM-NVIDIATritonServer.md
+++ b/website/docs/blueprints/inference/GPUs/vLLM-NVIDIATritonServer.md
@@ -112,7 +112,7 @@ Navigate into one of the example directories and run `install.sh` script
 
 **Important Note:**
 
-**Step1**: Ensure that you update the region in the `variables.tf` file before deploying the blueprint.
+**Step1**: Ensure that you update the region in the `blueprint.tfvars` file before deploying the blueprint.
 Additionally, confirm that your local region setting matches the specified region to prevent any discrepancies.
 
 For example, set your `export AWS_DEFAULT_REGION="<REGION>"` to the desired region:

--- a/website/docs/blueprints/inference/GPUs/vLLM-rayserve.md
+++ b/website/docs/blueprints/inference/GPUs/vLLM-rayserve.md
@@ -67,7 +67,7 @@ git clone https://github.com/awslabs/ai-on-eks.git
 
 **Important Note:**
 
-**Step1**: Ensure that you update the region in the `variables.tf` file before deploying the blueprint.
+**Step1**: Ensure that you update the region in the `blueprint.tfvars` file before deploying the blueprint.
 Additionally, confirm that your local region setting matches the specified region to prevent any discrepancies.
 
 For example, set your `export AWS_DEFAULT_REGION="<REGION>"` to the desired region:

--- a/website/docs/blueprints/inference/Neuron/Mistral-7b-inf2.md
+++ b/website/docs/blueprints/inference/Neuron/Mistral-7b-inf2.md
@@ -57,7 +57,7 @@ git clone https://github.com/awslabs/ai-on-eks.git
 
 Navigate into one of the example directories and run `install.sh` script
 
-**Important Note:** Ensure that you update the region in the `variables.tf` file before deploying the blueprint.
+**Important Note:** Ensure that you update the region in the `blueprint.tfvars` file before deploying the blueprint.
 Additionally, confirm that your local region setting matches the specified region to prevent any discrepancies.
 For example, set your `export AWS_DEFAULT_REGION="<REGION>"` to the desired region:
 

--- a/website/docs/blueprints/inference/Neuron/llama2-inf2.md
+++ b/website/docs/blueprints/inference/Neuron/llama2-inf2.md
@@ -105,7 +105,7 @@ git clone https://github.com/awslabs/ai-on-eks.git
 
 Navigate into one of the example directories and run `install.sh` script
 
-**Important Note:** Ensure that you update the region in the `variables.tf` file before deploying the blueprint.
+**Important Note:** Ensure that you update the region in the `blueprint.tfvars` file before deploying the blueprint.
 Additionally, confirm that your local region setting matches the specified region to prevent any discrepancies.
 For example, set your `export AWS_DEFAULT_REGION="<REGION>"` to the desired region:
 

--- a/website/docs/blueprints/inference/Neuron/llama3-inf2.md
+++ b/website/docs/blueprints/inference/Neuron/llama3-inf2.md
@@ -90,7 +90,7 @@ git clone https://github.com/awslabs/ai-on-eks.git
 
 Navigate into one of the example directories and run `install.sh` script
 
-**Important Note:** Ensure that you update the region in the `variables.tf` file before deploying the blueprint.
+**Important Note:** Ensure that you update the region in the `blueprint.tfvars` file before deploying the blueprint.
 Additionally, confirm that your local region setting matches the specified region to prevent any discrepancies.
 For example, set your `export AWS_DEFAULT_REGION="<REGION>"` to the desired region:
 

--- a/website/docs/blueprints/inference/Neuron/stablediffusion-inf2.md
+++ b/website/docs/blueprints/inference/Neuron/stablediffusion-inf2.md
@@ -80,7 +80,7 @@ git clone https://github.com/awslabs/ai-on-eks.git
 
 Navigate into one of the example directories and run `install.sh` script
 
-**Important Note:** Ensure that you update the region in the `variables.tf` file before deploying the blueprint.
+**Important Note:** Ensure that you update the region in the `blueprint.tfvars` file before deploying the blueprint.
 Additionally, confirm that your local region setting matches the specified region to prevent any discrepancies.
 For example, set your `export AWS_DEFAULT_REGION="<REGION>"` to the desired region:
 

--- a/website/docs/blueprints/inference/Neuron/vllm-ray-inf2.md
+++ b/website/docs/blueprints/inference/Neuron/vllm-ray-inf2.md
@@ -91,7 +91,7 @@ git clone https://github.com/awslabs/ai-on-eks.git
 
 Navigate into the following directory and run `install.sh` script:
 
-**Important Note:** Ensure that you update the region in the `variables.tf` file before deploying the blueprint.
+**Important Note:** Ensure that you update the region in the `blueprint.tfvars` file before deploying the blueprint.
 Additionally, confirm that your local region setting matches the specified region to prevent any discrepancies.
 For example, set your `export AWS_DEFAULT_REGION="<REGION>"` to the desired region.
 

--- a/website/docs/blueprints/training/GPUs/bionemo.md
+++ b/website/docs/blueprints/training/GPUs/bionemo.md
@@ -64,7 +64,7 @@ cd ai-on-eks/infra/bionemo
 
 #### Run the install script
 
-Use the provided helper script `install.sh` to run the terraform init and apply commands. By default the script deploys EKS cluster to `us-west-2` region. Update `variables.tf` to change the region. This is also the time to update any other input variables or make any other changes to the terraform template.
+Use the provided helper script `install.sh` to run the terraform init and apply commands. By default the script deploys EKS cluster to `us-west-2` region. Update `blueprint.tfvars` to change the region. This is also the time to update any other input variables or make any other changes to the terraform template.
 
 
 ```bash

--- a/website/docs/infra/ai-ml/aibrix.md
+++ b/website/docs/infra/ai-ml/aibrix.md
@@ -41,7 +41,7 @@ Ensure that you have installed the following tools on your machine.
 
 ### Deploy
 
-Clone the repository
+**1. Clone the repository:**
 
 ```bash
 git clone https://github.com/awslabs/ai-on-eks.git
@@ -52,14 +52,13 @@ If you are using profile for authentication
 set your `export AWS_PROFILE="<PROFILE_name>"` to the desired profile name
 :::
 
+**2. Review and customize configurations:**
+
+- Check available addons in `infra/base/terraform/variables.tf`
+- Modify addon settings in `infra/aibrix/terraform/blueprint.tfvars` as needed
+- Update the AWS region in `blueprint.tfvars`
+
 Navigate into aibrix and run `install.sh` script
-
-:::info
-Ensure that you update the region in the `variables.tf` file before deploying the blueprint.
-Additionally, confirm that your local region setting matches the specified region to prevent any discrepancies.
-For example, set your `export AWS_DEFAULT_REGION="<REGION>"` to the desired region:
-:::
-
 
 ```bash
 cd ai-on-eks/infra/aibrix

--- a/website/docs/infra/ai-ml/jupyterhub.md
+++ b/website/docs/infra/ai-ml/jupyterhub.md
@@ -87,16 +87,18 @@ This blueprint provides support for three authentication mechanisms: `dummy` and
 
 **Type1 Deployment config changes:**
 
-Only update the `region` variable in the `variables.tf` file.
+Only update the `region` variable in the `blueprint.tfvars` file.
 
 **Type2 Deployment config changes:**
 
-Update the `variables.tf` file with the following variables:
+Update the `blueprint.tfvars` file with the following variables:
  - `acm_certificate_domain`
  - `jupyterhub_domain`
  - `jupyter_hub_auth_mechanism=cognito`
 
 **Type3 Deployment config changes:**
+
+Update the `blueprint.tfvars` file with the following variables:
 - `acm_certificate_domain`
 - `jupyterhub_domain`
 - `jupyter_hub_auth_mechanism=oauth`


### PR DESCRIPTION
### What does this PR do?

Updates AIoEKS documentation in `website/docs` to correctly reflect the [Contribution Guide recommended pattern](https://github.com/awslabs/ai-on-eks/blob/main/CONTRIBUTION_GUIDE.md#contributing-core-infrastructure) using `blueprints.tfvars` to override the default variables defined in `infra/base/terraform/variables.tf`.

Resolves #77


### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [X] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [X] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
