### PR TITLE
Update Nvidia config from P6-B200 testing

### DIFF
--- a/infra/base/terraform/addons.tf
+++ b/infra/base/terraform/addons.tf
@@ -253,7 +253,8 @@ module "data_addons" {
   # Otherwise, you'll encounter the "No devices found..." error. Restart the pod after attaching an EFA device, or use a node selector to prevent incompatible scheduling.
   enable_aws_efa_k8s_device_plugin = var.enable_aws_efa_k8s_device_plugin
   aws_efa_k8s_device_plugin_helm_config = {
-    values = [file("${path.module}/helm-values/aws-efa-k8s-device-plugin-values.yaml")]
+    version = "v0.5.13"
+    values  = [file("${path.module}/helm-values/aws-efa-k8s-device-plugin-values.yaml")]
   }
 
   #---------------------------------------------------------------

--- a/infra/base/terraform/argocd-addons/nvidia-dra-driver.yaml
+++ b/infra/base/terraform/argocd-addons/nvidia-dra-driver.yaml
@@ -10,11 +10,10 @@ spec:
   source:
     repoURL: https://helm.ngc.nvidia.com/nvidia
     chart: nvidia-dra-driver-gpu
-    targetRevision: "25.3.0-rc.2"
+    targetRevision: "25.3.0-rc.4"
     helm:
       values: |
         nvidiaDriverRoot: /
-        nvidiaCtkPath: /usr/bin/nvidia-ctk
         gpuResourcesEnabledOverride: true # Required to deploy GPU and MIG deviceclasses
 
         resources:

--- a/infra/base/terraform/argocd-addons/nvidia-gpu-operator.yaml
+++ b/infra/base/terraform/argocd-addons/nvidia-gpu-operator.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://nvidia.github.io/gpu-operator
+    repoURL: https://helm.ngc.nvidia.com/nvidia
     chart: gpu-operator
-    targetRevision: "v24.9.2"
+    targetRevision: "v25.3.1"
     helm:
       values: |
         # Disable driver installation since EKS AMI already has drivers
@@ -40,6 +40,7 @@ spec:
                       mig-enabled: false
 
                   # P4D profiles (A100 40GB)
+                  # https://docs.nvidia.com/datacenter/tesla/mig-user-guide/index.html#a100-mig-profiles
                   p4d-half-balanced:
                     - devices: [0, 1, 2, 3]
                       mig-enabled: true
@@ -79,6 +80,7 @@ spec:
                       mig-enabled: false
 
                   # P4DE profiles (A100 80GB)
+                  # https://docs.nvidia.com/datacenter/tesla/mig-user-guide/index.html#a100-mig-profiles
                   p4de-half-balanced:
                     - devices: [0, 1, 2, 3]
                       mig-enabled: true
@@ -132,6 +134,7 @@ spec:
                       mig-enabled: false
 
                   # P5 profiles (H100 80GB)
+                  # https://docs.nvidia.com/datacenter/tesla/mig-user-guide/index.html#h100-mig-profiles
                   p5-half-balanced:
                     - devices: [0, 1, 2, 3]
                       mig-enabled: true
@@ -157,6 +160,33 @@ spec:
                     - devices: [6, 7]
                       mig-enabled: false
 
+                  # P6 profiles (B200 180GB)
+                  # https://docs.nvidia.com/datacenter/tesla/mig-user-guide/index.html#h200-mig-profiles
+                  p6-b200-half-balanced:
+                    - devices: [0, 1, 2, 3]
+                      mig-enabled: true
+                      mig-devices:
+                        "1g.23gb": 1
+                        "2g.45gb": 1
+                        "4g.90gb": 1
+                    - devices: [4, 5, 6, 7]
+                      mig-enabled: false
+
+                  p6-b200-all-small:
+                    - devices: all
+                      mig-enabled: true
+                      mig-devices:
+                        "1g.23gb": 7
+
+                  p6-b200-inference-optimized:
+                    - devices: [0, 1, 2, 3, 4, 5]
+                      mig-enabled: true
+                      mig-devices:
+                        "1g.23gb": 5
+                        "2g.40gb": 1
+                    - devices: [6, 7]
+                      mig-enabled: false
+
         # Device plugin configuration
         devicePlugin:
           enabled: true
@@ -165,9 +195,9 @@ spec:
             create: false
             default: ""
 
-        # Enable other components
+        # EKS AMIs come with the container toolkit installed
         toolkit:
-          enabled: true
+          enabled: false
 
         # Node feature discovery
         nfd:

--- a/infra/base/terraform/eks.tf
+++ b/infra/base/terraform/eks.tf
@@ -185,6 +185,7 @@ module "eks" {
       labels = {
         NodeGroupType            = "g6-mng"
         "nvidia.com/gpu.present" = "true"
+        "accelerator"            = "nvidia"
       }
 
       min_size     = 0
@@ -237,6 +238,7 @@ module "eks" {
       # Check mig profiel config in infra/base/terraform/argocd-addons/nvidia-gpu-operator.yaml
       labels = {
         "nvidia.com/gpu.present"        = "true"
+        "accelerator"                   = "nvidia"
         "nvidia.com/gpu.product"        = "A100-SXM4-80GB"
         "nvidia.com/mig.config"         = "p4de-half-balanced" # References GPU Operator embedded MIG profile
         "node-type"                     = "p4de"


### PR DESCRIPTION
### What does this PR do?
- Bumps the EFA device plugin chart version from `0.4.4` -> `0.5.13` which adds the P6 to the supported instances and resolves an issue with interface assignments (more details in the issue open on the data addons repo: https://github.com/aws-ia/terraform-aws-eks-data-addons/issues/53)
- Bumps the nvidia-dra-driver-gpu chart to the latest
- Updates the repo for the gpu-operator helm chart to be Nvidia's helm repo and bumped to latest.
- Added MIG profiles for the P6-B200 to the gpu-operator (I tested the half-balanced profile)
- Disables the container toolkit installation in the gpu-operator as the EKS AMIs should include that.
- Adds the `accelerator=nvidia` label to the GPU nodegroups so the device plugin and daemonsets are scheduled as expected.


### Motivation

I used the jark-stack example as a base for testing DRA + MIG and such on the P6-B200 instance and found a few papercuts to getting the instance up and running at 100%.

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [X] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

With these changes I was able to use the P6-B200 with DRA and MIG workloads. I'll add the full nodegroup config below as a comment but its really the same as the existing `cbr` nodegroup with a different instance type.
