### PR TITLE
Adding vectordb modules under infra/base 

### DIFF
--- a/infra/base/terraform/addons.tf
+++ b/infra/base/terraform/addons.tf
@@ -590,6 +590,101 @@ module "data_addons" {
       EOT
       ]
     }
+    # Graviton Nodepools
+    arm64-cpu-karpenter = {
+      values = [
+        <<-EOT
+      name: arm64-cpu-karpenter
+      clusterName: ${module.eks.cluster_name}
+      ec2NodeClass:
+        amiSelectorTerms:
+          - alias: bottlerocket@latest
+        karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
+        subnetSelectorTerms:
+          id: ${module.vpc.private_subnets[2]}
+        securityGroupSelectorTerms:
+          tags:
+            Name: ${module.eks.cluster_name}-node
+        blockDeviceMappings:
+          # Root device
+          - deviceName: /dev/xvda
+            ebs:
+              volumeSize: 100Gi
+              volumeType: gp3
+              encrypted: true
+          # Data device: Container resources such as images and logs
+          - deviceName: /dev/xvdb
+            ebs:
+              volumeSize: 300Gi
+              volumeType: gp3
+              encrypted: true
+              ${var.bottlerocket_data_disk_snapshot_id != null ? "snapshotID: ${var.bottlerocket_data_disk_snapshot_id}" : ""}
+      nodePool:
+        labels:
+          - instanceType: arm64-cpu-karpenter
+          - type: karpenter
+        requirements:
+          - key: "karpenter.k8s.aws/instance-family"
+            operator: In
+            values: ["m7g","r8g","c7g"] # Instance choices should be determined as per workload and nodePool/s should be modified accordingly
+          - key: "kubernetes.io/arch"
+            operator: In
+            values: ["arm64"]
+          - key: "karpenter.sh/capacity-type"
+            operator: In
+            values: [ "on-demand"]
+        limits:
+          cpu: 1000
+        disruption:
+          consolidationPolicy: WhenEmpty
+          consolidateAfter: 300s
+          expireAfter: 720h
+        weight: 100
+      EOT
+      ]
+    }
+    arm64-cpu-ssd-karpenter = {
+      values = [
+        <<-EOT
+      name: arm64-cpu-ssd-karpenter
+      clusterName: ${module.eks.cluster_name}
+      ec2NodeClass:
+        amiSelectorTerms:
+          - alias: bottlerocket@latest
+        karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
+        subnetSelectorTerms:
+          id: ${module.vpc.private_subnets[2]}
+        securityGroupSelectorTerms:
+          tags:
+            Name: ${module.eks.cluster_name}-node
+        instanceStorePolicy: RAID0
+      nodePool:
+        labels:
+          - instanceType: arm64-cpu-ssd-karpenter
+          - type: karpenter
+        requirements:
+          - key: "karpenter.k8s.aws/instance-family"
+            operator: In
+            values: ["r7gd"] # Instance choices should be determined as per workload and nodePool/s should be modified accordingly
+          - key: "karpenter.k8s.aws/instance-size"
+            operator: In
+            values: [ "4xlarge","8xlarge" ]
+          - key: "kubernetes.io/arch"
+            operator: In
+            values: ["arm64"]
+          - key: "karpenter.sh/capacity-type"
+            operator: In
+            values: ["on-demand"]
+        limits:
+          cpu: 1000
+        disruption:
+          consolidationPolicy: WhenEmpty
+          consolidateAfter: 300s
+          expireAfter: 720h
+        weight: 100
+      EOT
+      ]
+    }
   }
 
   depends_on = [

--- a/infra/base/terraform/argocd-addons/vectordb-milvus-operator.yaml
+++ b/infra/base/terraform/argocd-addons/vectordb-milvus-operator.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: milvus
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io/background
+spec:
+  project: default
+  source:
+    chart: milvus-operator
+    repoURL: https://zilliztech.github.io/milvus-operator/
+    targetRevision: "v1.2.6"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: milvus
+  syncPolicy:
+    syncOptions:
+      - ServerSideApply=true
+      - CreateNamespace=true
+    automated:
+      prune: true
+      selfHeal: true
+    managedNamespaceMetadata:
+      labels:
+        argocd.argoproj.io/instance: milvus
+      annotations:
+        argocd.argoproj.io/tracking-id: >-
+          milvus:/milvus:milvus/milvus

--- a/infra/base/terraform/argocd-addons/vectordb-qdrant-helm.yaml
+++ b/infra/base/terraform/argocd-addons/vectordb-qdrant-helm.yaml
@@ -1,0 +1,55 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: qdrant
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://qdrant.github.io/qdrant-helm
+    chart: qdrant
+    targetRevision : 1.14.1
+    helm:
+      values: |
+        # From https://github.com/qdrant/qdrant-helm/blob/main/charts/qdrant/values.yaml
+        replicaCount: 3
+        nodeSelector:
+          instanceType: "arm64-cpu-ssd-karpenter"           
+        resources:
+          limits:
+            cpu: "4"
+            memory: "16G"
+          requests:
+            cpu: "4"
+            memory: "16G"
+        config:
+          cluster:
+            enabled: true
+            p2p:
+              port: 6335
+              enable_tls: false
+            consensus:
+              tick_period_ms: 100
+        # In production scenario apiKey should be set for Authentication, an external secret can be used here
+        apiKey: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: qdrant
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    automated:
+      prune: true
+      selfHeal: true
+    managedNamespaceMetadata:
+      labels:
+        argocd.argoproj.io/instance: qdrant
+      annotations:
+        argocd.argoproj.io/tracking-id: >-
+          qdrant:/qdrant:qdrant/qdrant
+
+
+

--- a/infra/base/terraform/argocd-addons/vectordb-weaviate-helm.yaml
+++ b/infra/base/terraform/argocd-addons/vectordb-weaviate-helm.yaml
@@ -1,0 +1,54 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: weaviate
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://weaviate.github.io/weaviate-helm/
+    chart: weaviate
+    targetRevision : 17.4.3
+    helm:
+      values: |
+        # From https://raw.githubusercontent.com/weaviate/weaviate-helm/refs/heads/master/weaviate/values.yaml 
+        replicas: 4
+        nodeSelector:
+          instanceType: "arm64-cpu-karpenter"
+        service:
+          name: weaviate
+          ports:
+            - name: http
+              protocol: TCP
+              port: 50052
+              # Target port is going to be the same for every port
+          type: ClusterIP
+        grpcService:
+          enabled: true
+          name: weaviate-grpc
+          ports:
+            - name: grpc
+              protocol: TCP
+              port: 50051
+              # Target port is going to be the same for every port
+          type: ClusterIP
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: weaviate
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    automated:
+      prune: true
+      selfHeal: true
+    managedNamespaceMetadata:
+      labels:
+        argocd.argoproj.io/instance: weaviate
+      annotations:
+        argocd.argoproj.io/tracking-id: >-
+          weaviate:/weaviate:weaviate/weaviate
+
+

--- a/infra/base/terraform/argocd_addons.tf
+++ b/infra/base/terraform/argocd_addons.tf
@@ -77,3 +77,24 @@ resource "kubectl_manifest" "nvidia_dcgm_exporter" {
     module.eks_blueprints_addons
   ]
 }
+
+# Milvus Operator
+resource "kubectl_manifest" "vectordb_milvus_yaml" {
+  count     = var.enable_vectordb_milvus ? 1 : 0
+  yaml_body = file("${path.module}/argocd-addons/vectordb-milvus-operator.yaml")
+  depends_on = [module.eks_blueprints_addons]
+}
+
+# Weaviate
+resource "kubectl_manifest" "vectordb_weaviate_yaml" {
+  count     = var.enable_vectordb_weaviate ? 1 : 0
+  yaml_body = file("${path.module}/argocd-addons/vectordb-weaviate-helm.yaml")
+  depends_on = [module.eks_blueprints_addons]
+}
+
+# Qdrant
+resource "kubectl_manifest" "vectordb_qdrant_yaml" {
+  count     = var.enable_vectordb_qdrant ? 1 : 0
+  yaml_body = file("${path.module}/argocd-addons/vectordb-qdrant-helm.yaml")
+  depends_on = [module.eks_blueprints_addons]
+}

--- a/infra/base/terraform/variables.tf
+++ b/infra/base/terraform/variables.tf
@@ -319,3 +319,24 @@ variable "enable_nvidia_dcgm_exporter" {
   type        = bool
   default     = true
 }
+
+#Milvus
+variable "enable_vectordb_milvus" {
+  description = "Enable VectorDB Milvus"
+  type        = bool
+  default     = false
+}
+
+#Weaviate
+variable "enable_vectordb_weaviate" {
+  description = "Enable Qdrant Milvus"
+  type        = bool
+  default     = false
+}
+
+#Qdrant
+variable "enable_vectordb_qdrant" {
+  description = "Enable Qdrant Milvus"
+  type        = bool
+  default     = false
+}

--- a/infra/vectordb/examples/README.md
+++ b/infra/vectordb/examples/README.md
@@ -1,0 +1,348 @@
+# VectorDB Examples
+
+This guide provides instructions for deploying and testing various vector databases on EKS using AWS Graviton Instances. These can be used as standalone applications or integrated with other ai-on-eks blueprints.
+
+## Common Prerequisites
+
+Before installing any vector database, ensure you have the following:
+
+- AWS CLI configured with appropriate permissions
+- kubectl installed and configured
+- Terraform >= 1.0
+- An existing EKS cluster or ability to create one
+- Helm 3.x installed
+
+## Common Installation Steps
+
+### Step 1: Clone and Navigate to the Repository
+
+```
+git clone https://github.com/awslabs/ai-on-eks.git
+cd ai-on-eks/infra/vectordb
+```
+
+### Step 2: Configure Terraform Variables
+
+Edit the `terraform/blueprint.tfvars` file to enable your desired vector database:
+
+```
+# Enable your desired vector database (choose one or more)
+enable_vectordb_milvus = true    # For Milvus
+enable_vectordb_qdrant = true    # For Qdrant
+enable_vectordb_weaviate = true  # For Weaviate
+```
+
+### Step 3: Deploy the Infrastructure
+
+Run the installation script to deploy the EKS cluster with vector database support:
+
+```
+chmod +x install.sh
+./install.sh
+```
+
+This script will:
+- Copy base Terraform configurations
+- Initialize Terraform
+- Deploy the EKS cluster with required addons
+- Install the selected vector database(s) via ArgoCD addons
+
+### Step 4: Verify EKS Cluster
+
+Confirm your EKS cluster is running:
+
+```
+kubectl get nodes
+kubectl get namespaces
+```
+
+## Common Troubleshooting
+
+### Common Issues and Solutions
+
+1. **Pods stuck in Pending state**
+   ```
+   kubectl describe pods -n <namespace>
+   # Check for resource constraints or node selector issues
+   ```
+
+2. **LoadBalancer service not getting external IP**
+   ```
+   # Check AWS Load Balancer Controller
+   kubectl get pods -n kube-system | grep aws-load-balancer
+   ```
+
+3. **Connection timeout**
+   ```
+   # Check security groups and network connectivity
+   kubectl get svc <service-name> -n <namespace> -o yaml
+   ```
+
+4. **Insufficient resources**
+   ```
+   # Check node resources
+   kubectl top nodes
+   kubectl describe nodes
+   ```
+
+---
+
+## Milvus
+
+Milvus is a cloud-native vector database designed for storing, indexing, and managing embedding vectors for similarity search and AI applications.
+
+### Milvus-Specific Installation Steps
+
+After completing the common installation steps with `enable_vectordb_milvus = true`:
+
+1. **Verify Milvus Operator Installation**:
+   ```
+   # Check if milvus-operator namespace exists
+   kubectl get namespace milvus
+   
+   # Verify Milvus operator pods are running
+   kubectl get pods -n milvus
+   
+   # Check ArgoCD applications (if ArgoCD is accessible)
+   kubectl get applications -n argocd | grep milvus
+   ```
+
+2. **Deploy Milvus Cluster**:
+   ```
+   # Deploy the Milvus cluster
+   kubectl apply -f examples/milvus_distributed.yaml -n milvus
+   ```
+
+   Note: The `milvus_distributed.yaml` file contains the Milvus cluster configuration optimized for AWS Graviton instances with ARM64 CPU and SSD storage.
+
+3. **Monitor Deployment**:
+   ```
+   # Check Milvus custom resource
+   kubectl get milvus my-release -n milvus
+   
+   # Check all pods in milvus namespace
+   kubectl get pods -n milvus
+   
+   ```
+
+4. **Get Connection Details**:
+   ```
+   kubectl get svc my-release-milvus -n milvus
+   ```
+### Testing Milvus
+
+Test Milvus connectivity using CURL:
+
+# Set up port forwarding in one terminal
+```
+kubectl port-forward svc/my-release-milvus 19530:19530 -n milvus
+```
+
+# In another terminal, test the connection
+```
+export CLUSTER_ENDPOINT="http://localhost:19530" # Replace with your Milvus cluster endpoint
+export TOKEN="root:Milvus" # Replace with your Milvus username:password
+```
+# List collections (should return empty list initially)
+```
+curl --request POST \
+  --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/list" \
+  --header 'accept: application/json' \
+  --header 'content-type: application/json' \
+  -d '{
+  "dbName": "default"
+  }'
+```
+
+If using LoadBalancer in production environment (replace EXTERNAL-IP with actual IP):
+
+### Milvus-Specific Commands
+
+```
+# Check Milvus logs
+kubectl logs -l app.kubernetes.io/name=milvus -n milvus
+
+# Scale Milvus components
+kubectl patch milvus my-release -n milvus --type='merge' -p='{"spec":{"components":{"queryNode":{"replicas":2}}}}'
+```
+
+---
+
+## Qdrant
+
+Qdrant is a vector similarity search engine with extended filtering support, designed to handle large collections of vectors.
+
+### Qdrant-Specific Installation Steps
+
+After completing the common installation steps with `enable_vectordb_qdrant = true`:
+
+1. **Verify Qdrant Deployment**:
+   
+   # Check if qdrant namespace exists
+   ```
+   kubectl get namespace qdrant
+   ```
+   # Verify Qdrant pods are running (should see 3 replicas)
+   ```
+   kubectl get pods -n qdrant
+   ```
+   
+   # Check ArgoCD applications (if ArgoCD is accessible)
+   ```
+   kubectl get applications -n argocd | grep qdrant
+   ```
+   
+   # Wait for all pods to be ready
+   ```
+   kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=qdrant -n qdrant --timeout=600s
+   ```
+
+2. **Monitor Deployment**:
+   
+   # Check StatefulSet
+   ```
+   kubectl get statefulset -n qdrant
+   ```
+   
+   # Check services
+   ```
+   kubectl get svc -n qdrant
+   ```
+
+3. **Get Connection Details**:
+   ```
+   kubectl get svc qdrant -n qdrant
+   ```
+   Note the service details - Qdrant will be accessible on port 6333 for HTTP API and port 6334 for gRPC.
+
+### Testing Qdrant
+
+Test Qdrant connectivity using CURL:
+
+# Set up port forwarding in one terminal
+```
+kubectl port-forward svc/qdrant 6333:6333 -n qdrant
+```
+
+# In another terminal, test the connection
+# Check cluster info
+```
+curl -X GET "http://localhost:6333/cluster"
+```
+# List collections (should return empty result initially)
+```
+curl -X GET "http://localhost:6333/collections"
+```
+# Check telemetry/health
+```
+curl -X GET "http://localhost:6333/telemetry"
+```
+If using LoadBalancer (replace EXTERNAL-IP with actual IP):
+
+
+### Qdrant-Specific Commands
+
+
+# Check Qdrant logs
+```
+kubectl logs -l app.kubernetes.io/name=qdrant -n qdrant
+```
+
+# Port forward for local testing
+```
+kubectl port-forward svc/qdrant 6333:6333 -n qdrant
+```
+# Check cluster status via API
+```
+curl http://localhost:6333/cluster
+```
+# Scale Qdrant replicas (if needed)
+```
+kubectl scale statefulset qdrant --replicas=10 -n qdrant
+```
+
+---
+
+## Weaviate
+
+Weaviate is an open-source vector search engine that stores both objects and vectors, allowing for combining vector search with structured filtering.
+
+### Weaviate-Specific Installation Steps
+
+After completing the common installation steps with `enable_vectordb_weaviate = true`:
+
+1. **Verify Weaviate Deployment**:
+   ```
+   # Check if weaviate namespace exists
+   kubectl get namespace weaviate
+   
+   # Verify Weaviate pods are running (should see 4 replicas)
+   kubectl get pods -n weaviate
+   
+   # Check ArgoCD applications (if ArgoCD is accessible)
+   kubectl get applications -n argocd | grep weaviate
+   
+   # Wait for all pods to be ready
+   kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=weaviate -n weaviate --timeout=600s
+   ```
+
+2. **Monitor Deployment**:
+   ```
+   # Check StatefulSet
+   kubectl get statefulset -n weaviate
+   
+   # Check services
+   kubectl get svc -n weaviate
+   ```
+
+3. **Get Connection Details**:
+   ```
+   kubectl get svc weaviate -n weaviate
+   ```
+   Note the service details - Weaviate will be accessible on port 8080 for HTTP API.
+
+### Testing Weaviate
+
+Test Weaviate connectivity using CURL:
+
+# Set up port forwarding in one terminal
+
+```
+kubectl port-forward svc/weaviate 50052:50052 -n weaviate
+```
+
+# In another terminal, test the connection
+
+# Check meta information (version, hostname, etc.)
+```
+curl -X GET "http://localhost:50052/v1/meta"
+```
+# List schema classes (should return empty classes initially)
+```
+curl -X GET "http://localhost:50052/v1/schema"
+```
+If using LoadBalancer (replace EXTERNAL-IP with actual IP):
+
+### Weaviate-Specific Commands
+
+# Check Weaviate logs
+
+```
+kubectl logs -l app.kubernetes.io/name=weaviate -n weaviate
+```
+
+# Scale Weaviate replicas (if needed)
+```
+kubectl scale statefulset weaviate --replicas=6 -n weaviate
+```
+
+## Next Steps
+
+- Explore the documentation for your chosen vector database:
+  - [Milvus documentation](https://milvus.io/docs)
+  - [Qdrant documentation](https://qdrant.tech/documentation/)
+  - [Weaviate documentation](https://weaviate.io/developers/weaviate)
+- Integrate with your AI/ML applications
+- Set up monitoring and alerting
+- Configure authentication for production use
+- Optimize cluster configuration based on your workload requirements

--- a/infra/vectordb/examples/milvus_distributed.yaml
+++ b/infra/vectordb/examples/milvus_distributed.yaml
@@ -1,0 +1,50 @@
+# This is a sample to deploy a milvus cluster with minimum cost of resources.
+# It should be used for testing and development purposes only.
+# Total resources required is about: 0.25 CPU, 512 MiB memory
+# When deleted, all the data in the Milvus will be lost.
+
+apiVersion: milvus.io/v1beta1
+kind: Milvus
+metadata:
+  name: my-release
+  labels:
+    app: milvus
+    namespace: milvus
+spec:
+  mode: cluster
+  config: {}
+  components:
+    enableRollingUpdate: true
+    imageUpdateMode: rollingUpgrade
+    nodeSelector:
+      instanceType: arm64-cpu-ssd-karpenter
+    proxy:
+      replicas: 1
+      serviceType: ClusterIP
+    dataNode:
+      replicas: 1
+    indexNode:
+      replicas: 1
+    queryNode:
+      replicas: 1
+    mixCoord:
+      replicas: 1
+  dependencies:
+    etcd:
+      inCluster:
+        values:
+          replicaCount: 1
+        deletionPolicy: Delete
+        pvcDeletion: true
+    storage:
+      inCluster:
+        values:
+          mode: standalone
+          resources:
+            requests:
+              memory: 100Mi
+          persistence:
+            size: 20Gi
+        deletionPolicy: Delete
+        pvcDeletion: true
+    msgStreamType: pulsar

--- a/infra/vectordb/install.sh
+++ b/infra/vectordb/install.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Copy the base into the folder
+mkdir -p ./terraform/_LOCAL
+cp -r ../base/terraform/* ./terraform/_LOCAL
+
+cd terraform/_LOCAL
+terraform init
+source ./install.sh

--- a/infra/vectordb/terraform/blueprint.tfvars
+++ b/infra/vectordb/terraform/blueprint.tfvars
@@ -1,0 +1,29 @@
+name                      = "vectordb-on-eks"
+enable_vectordb_milvus  = false
+enable_vectordb_weaviate  = false
+enable_vectordb_qdrant  = false
+# region                    = "us-west-2"
+# eks_cluster_version       = "1.33"
+
+# -------------------------------------------------------------------------------------
+# EKS Addons Configuration
+#
+# These are the EKS Cluster Addons managed by Terrafrom stack.
+# You can enable or disable any addon by setting the value to `true` or `false`.
+#
+# If you need to add a new addon that isn't listed here:
+# 1. Add the addon name to the `enable_cluster_addons` variable in `base/terraform/variables.tf`
+# 2. Update the `locals.cluster_addons` logic in `eks.tf` to include any required configuration
+#
+# -------------------------------------------------------------------------------------
+
+ enable_cluster_addons = {
+   coredns                         = true
+   kube-proxy                      = true
+   vpc-cni                         = true
+   eks-pod-identity-agent          = true
+   aws-ebs-csi-driver              = true
+   metrics-server                  = true
+   eks-node-monitoring-agent       = true
+   amazon-cloudwatch-observability = true
+ }

--- a/website/docs/infra/ai-ml/index.md
+++ b/website/docs/infra/ai-ml/index.md
@@ -68,6 +68,9 @@ Each stack inherits the `base` stack's components. These components include:
 | `enable_mpi_operator`                    | Enable the MPI Operator                             | `false`                  |
 | `enable_aibrix_stack`                    | Enable the AIBrix stack                             | `false`                  |
 | `aibrix_stack_version`                   | AIBrix Stack version                                | `v0.2.1`                 |
+| `enable_vectordb_milvus`                 | Enable Milvus                                       | `false`                  |
+| `enable_vectordb_weaviate`               | Enable Weaviate                                     | `false`                  |
+| `enable_vectordb_qdrant`                 | Enable Qdrant                                       | `false`                  |
 
 ### JupyterHub
 


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/ai-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

Adding Milvus, Qdrant, and Weaviate implementation under infra/base and infra/vectordb using ArgoCD
Adding Graviton nodepools 
Modifying website and other files as required

### Motivation

VectorDB is essential for running AI implementation patterns such as RAG and Agentic AI applications as a knowledge base. This will provide reusable implementations that run on AWS Graviton to deliver price-performance benefits.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [x] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
