### PR TITLE
Allow specifying how many AZs to use for each deployment

### DIFF
--- a/infra/base/terraform/addons.tf
+++ b/infra/base/terraform/addons.tf
@@ -309,7 +309,9 @@ module "data_addons" {
         amiFamily: Bottlerocket
         karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
         subnetSelectorTerms:
-          id: ${module.vpc.private_subnets[2]}
+          tags:
+            karpenter.sh/discovery: "${module.eks.cluster_name}"
+            Name: "${module.eks.cluster_name}-private-secondary*" # Only seconddary cidr subnets
         securityGroupSelectorTerms:
           tags:
             Name: ${module.eks.cluster_name}-node
@@ -365,7 +367,9 @@ module "data_addons" {
           - alias: bottlerocket@latest
         karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
         subnetSelectorTerms:
-          id: ${module.vpc.private_subnets[2]}
+          tags:
+            karpenter.sh/discovery: "${module.eks.cluster_name}"
+            Name: "${module.eks.cluster_name}-private-secondary*" # Only seconddary cidr subnets
         securityGroupSelectorTerms:
           tags:
             Name: ${module.eks.cluster_name}-node
@@ -429,7 +433,9 @@ module "data_addons" {
           - alias: bottlerocket@latest
         karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
         subnetSelectorTerms:
-          id: ${module.vpc.private_subnets[3]}
+          tags:
+            karpenter.sh/discovery: "${module.eks.cluster_name}"
+            Name: "${module.eks.cluster_name}-private-secondary*" # Only seconddary cidr subnets
         securityGroupSelectorTerms:
           tags:
             Name: ${module.eks.cluster_name}-node
@@ -485,7 +491,9 @@ module "data_addons" {
           - alias: bottlerocket@latest
         karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
         subnetSelectorTerms:
-          id: ${module.vpc.private_subnets[2]}
+          tags:
+            karpenter.sh/discovery: "${module.eks.cluster_name}"
+            Name: "${module.eks.cluster_name}-private-secondary*" # Only seconddary cidr subnets
         securityGroupSelectorTerms:
           tags:
             Name: ${module.eks.cluster_name}-node
@@ -544,7 +552,9 @@ module "data_addons" {
           - alias: bottlerocket@latest
         karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
         subnetSelectorTerms:
-          id: ${module.vpc.private_subnets[2]}
+          tags:
+            karpenter.sh/discovery: "${module.eks.cluster_name}"
+            Name: "${module.eks.cluster_name}-private-secondary*" # Only seconddary cidr subnets
         securityGroupSelectorTerms:
           tags:
             Name: ${module.eks.cluster_name}-node

--- a/infra/base/terraform/efs.tf
+++ b/infra/base/terraform/efs.tf
@@ -14,7 +14,7 @@ module "efs" {
 
   # Mount targets / security group
   mount_targets = {
-    for k, v in zipmap(local.azs, slice(module.vpc.private_subnets, length(module.vpc.private_subnets) - 2, length(module.vpc.private_subnets))) : k => { subnet_id = v }
+    for k, v in zipmap(local.azs, slice(module.vpc.private_subnets, length(module.vpc.private_subnets) - var.availability_zones_count, length(module.vpc.private_subnets))) : k => { subnet_id = v }
   }
   security_group_description = "${local.name} EFS security group"
   security_group_vpc_id      = module.vpc.vpc_id

--- a/infra/base/terraform/main.tf
+++ b/infra/base/terraform/main.tf
@@ -49,7 +49,7 @@ data "aws_iam_session_context" "current" {
 locals {
   name                   = var.name
   region                 = var.region
-  azs                    = slice(data.aws_availability_zones.available.names, 0, 2)
+  azs                    = slice(data.aws_availability_zones.available.names, 0, var.availability_zones_count)
   partition              = data.aws_partition.current.partition
   account_id             = data.aws_caller_identity.current.account_id
   mlflow_name            = "mlflow"

--- a/infra/base/terraform/variables.tf
+++ b/infra/base/terraform/variables.tf
@@ -16,11 +16,27 @@ variable "eks_cluster_version" {
   type        = string
 }
 
-# VPC with 2046 IPs (10.1.0.0/21) and 2 AZs
+# VPC with configurable AZs - CIDR size should match AZ count
 variable "vpc_cidr" {
-  description = "VPC CIDR. This should be a valid private (RFC 1918) CIDR range"
-  default     = "10.1.0.0/21"
+  description = "VPC CIDR. This should be a valid private (RFC 1918) CIDR range. Recommended: /21 for 2 AZs, /20 for 3 AZs, /19 for 4 AZs. If the network prefix is not provided, it will be computed"
+  default     = "10.1.0.0"
   type        = string
+}
+
+variable "availability_zones_count" {
+  description = "Number of availability zones to use for the deployment"
+  type        = number
+  default     = 2
+  validation {
+    condition     = var.availability_zones_count >= 2 && var.availability_zones_count <= 4
+    error_message = "The availability_zones_count must be between 2 and 4."
+  }
+}
+
+variable "single_nat_gateway" {
+  description = "Use a single NAT Gateway for all AZs (cost-effective for dev/test). Set to false for production to use one NAT Gateway per AZ for high availability."
+  type        = bool
+  default     = true
 }
 
 # RFC6598 range 100.64.0.0/10


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/ai-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

Allows specifying between 2 and 4 AZs to use for an infrastructure deployment. Maintains backwards compatibility by defaulting to 2 and allowing you to specify the subnet mask for the CIDR range. Also uses multiple AZs for each nodegroup. 

### Motivation
Fixes #67 

The current infrastructure restricts us to 2 AZs in the region (A/B). This is a potential problem from a well-architected perspective as well as node acquisition: sometimes nodes aren't available in one of those regions. Additionally, this PR relaxes the constraint of node groups being only in 1 AZ. As we now support topology awareness in the inference blueprints, having more AZs available for inference services shouldn't be as problematic. 

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
