### PR TITLE
disable aibrix load balancer by default

### DIFF
--- a/infra/base/terraform/argocd-addons/aibrix-core.yaml
+++ b/infra/base/terraform/argocd-addons/aibrix-core.yaml
@@ -9,6 +9,19 @@ spec:
     repoURL: https://github.com/vllm-project/aibrix.git
     targetRevision: ${aibrix_version}
     path: config/overlays/release
+    # Disable the load balancer by default
+    kustomize:
+      patches:
+        - target:
+            kind: EnvoyProxy
+            name: aibrix-custom-proxy-config
+            namespace: aibrix-system
+          patch: |-
+            - op: add
+              path: /spec/provider/kubernetes
+              value:
+                envoyService:
+                  type: ClusterIP
   destination:
     server: https://kubernetes.default.svc
     namespace: aibrix-system


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/ai-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

Fixes: #142 
Disables the AIBrix LB on deployment

### Motivation

We should default to not having load balancers created

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
