### PR TITLE
Fix CBR deployment issue

### DIFF
--- a/infra/base/terraform/eks.tf
+++ b/infra/base/terraform/eks.tf
@@ -206,7 +206,7 @@ module "eks" {
     }
 
 
-    }, local.has_secondary_subnets ? {
+    }, length(var.capacity_block_reservation_id) > 0 ? {
     cbr = {
       ami_type       = "AL2023_x86_64_NVIDIA"
       instance_types = ["p4de.24xlarge"]
@@ -272,7 +272,7 @@ module "eks" {
       # }
       # capacity_reservation_specification = {
       #   capacity_reservation_target = {
-      #     capacity_reservation_id = "cr-abcedefgh" # Replace with your capacity reservation ID
+      #     capacity_reservation_id = var.capacity_block_reservation_id # Replace with your capacity reservation ID
       #   }
       # }
     }

--- a/infra/base/terraform/variables.tf
+++ b/infra/base/terraform/variables.tf
@@ -16,6 +16,12 @@ variable "eks_cluster_version" {
   type        = string
 }
 
+variable "capacity_block_reservation_id" {
+  description = "ID of capacity block reservation"
+  default     = ""
+  type        = string
+}
+
 # VPC with configurable AZs - CIDR size should match AZ count
 variable "vpc_cidr" {
   description = "VPC CIDR. This should be a valid private (RFC 1918) CIDR range. Recommended: /21 for 2 AZs, /20 for 3 AZs, /19 for 4 AZs. If the network prefix is not provided, it will be computed"


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/ai-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

This PR adds a variable for the CBR ID and only creates a CBR if it exists

### Motivation

Fixes the CBR deployment issue and makes it easier to update the CBR ID

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
