### PR TITLE
fix: remove invalid headService.metadata.name from vllm-rayserve-depl…

### DIFF
--- a/blueprints/inference/vllm-rayserve-inf2/vllm-rayserve-deployment.yaml
+++ b/blueprints/inference/vllm-rayserve-inf2/vllm-rayserve-deployment.yaml
@@ -205,7 +205,6 @@ spec:
     headGroupSpec:
       headService:
         metadata:
-          name: vllm
           namespace: vllm
       rayStartParams:
         dashboard-host: '0.0.0.0'


### PR DESCRIPTION
### What does this PR do?
Fixes invalid RayService configuration in `vllm-rayserve-deployment.yaml` by removing the `name: vllm` field from `spec.rayClusterConfig.headGroupSpec.headService.metadata` that causes KubeRay operator validation failure.

### Motivation
Users attempting to deploy the vLLM Ray Service on Inferentia2 encounter a deployment failure with error: "The RayService spec is invalid vllm/vllm-llama3-inf2: spec.rayClusterConfig.headGroupSpec.headService.metadata.name should not be set". This prevents the entire vLLM inference deployment from working, blocking users from running Llama3 models on AWS Inferentia2 instances via EKS.

### More
- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [] Yes, I ran `pre-commit run -a` with this PR. Link for installing [[pre-commit](https://pre-commit.com/)](https://pre-commit.com/) locally

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes
**Test Evidence**: After applying the fix, the RayService deployed successfully with both head and worker pods running:
```
pod/vllm-llama3-inf2-2bzdc-head                      2/2     Running   0          14m
pod/vllm-llama3-inf2-2bzdc-inf2-group-worker-s8rs4   1/1     Running   0          14m
raycluster.ray.io/vllm-llama3-inf2-2bzdc   1                 1                   32     130G     0      ready    14m
```

**Root Cause**: The KubeRay operator validates that `headService.metadata.name` should not be manually set as it generates this automatically. The invalid configuration prevented the RayService from being created.

**Impact**: This fix enables users to successfully deploy vLLM with Llama3 models on Inferentia2 instances using the provided blueprint.