### PR TITLE
Update aibrix cleanup script path and add troubleshooting section karpenter STS error

### DIFF
--- a/website/docs/infra/aibrix.md
+++ b/website/docs/infra/aibrix.md
@@ -149,7 +149,7 @@ To avoid unwanted charges to your AWS account, delete all the AWS resources crea
 This script will cleanup the environment using `-target` option to ensure all the resources are deleted in correct order.
 
 ```bash
-cd ai-on-eks/infra/aibrix/terraform
+cd ai-on-eks/infra/aibrix/terraform/_LOCAL
 ./cleanup.sh
 ```
 

--- a/website/docs/infra/troubleshooting/troubleshooting.md
+++ b/website/docs/infra/troubleshooting/troubleshooting.md
@@ -237,6 +237,21 @@ You will need to create the service linked role in the AWS account you're using 
 aws iam create-service-linked-role --aws-service-name spot.amazonaws.com
 ```
 
+
+## Karpenter in CrashLoopBackOff after deployment - STS error
+
+After deployment, when checking karpenter pods it is in CrashLoopBackOff state with the following logs:
+```
+{"level":"ERROR","time":"2025-09-30T12:52:27.746Z","logger":"controller","message":"ec2 api connectivity check failed","commit":"13242ea","error":"operation error EC2: DescribeInstanceTypes,
+get identity: get credentials: failed to refresh cached credentials, failed to retrieve credentials, operation error STS: AssumeRoleWithWebIdentity, https response error StatusCode: 403, RequestID: xxx, RegionDisabledException: STS is not activated in this region for account:xxxxx. Your account administrator can activate STS in this region using the IAM Console."}
+```
+
+## Solution:
+
+The message "STS is not activated in this region for account" means an AWS account administrator must enable the AWS Security Token Service (STS) in the specific region where the request is being made before any requests to generate temporary credentials can succeed. You can activate STS for the region using the AWS IAM console on the Account Settings page, which also shows which regions are currently active.
+
+Documentation link: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html
+
 ## Error: AmazonEKS_CNI_IPv6_Policy does not exist
 If you encounter the error below when deploying a solution that supports IPv6:
 


### PR DESCRIPTION
### What does this PR do?

Fix path for cleanup in aibrix example documentation.

Add section for STS troubleshooting, just happened when tried to use eu-west-2 in my account.
Accounts may have some regions with STS disabled, specially new regions, which leads to karpenter error described in the troubleshooting:
```
{"level":"ERROR","time":"2025-09-30T12:52:27.746Z","logger":"controller","message":"ec2 api connectivity check failed","commit":"13242ea","error":"operation error EC2: DescribeInstanceTypes,
get identity: get credentials: failed to refresh cached credentials, failed to retrieve credentials, operation error STS: AssumeRoleWithWebIdentity, https response error StatusCode: 403, RequestID: b839db9e-4669-481b-8fc8-76f57ff6c395, RegionDisabledException: STS is not activated in this region for account:597086626653. Your account administrator can activate STS in this region using the IAM Console."}
```

<!-- A brief description of the change being made with this pull request. -->

### Motivation

Improve usability and update documentation.
<!-- What inspired you to submit this pull request? -->

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

Error in the pod in the cluster that was deployed, account and requestid redacted out:
```
❯ kubectl -n karpenter logs --all-containers deployments.apps/karpenter --previous
Found 2 pods, using pod/karpenter-7845dd568b-kdmlp
{"level":"ERROR","time":"2025-09-30T12:55:08.675Z","logger":"controller","message":"ec2 api connectivity check failed","commit":"13242ea","error":"operation error EC2: DescribeInstanceTypes, get identity: get credentials: failed to refresh cached credentials, failed to retrieve credentials, operation error STS: AssumeRoleWithWebIdentity, https response error StatusCode: 403, RequestID: xxxx, RegionDisabledException: STS is not activated in this region for account:xxxxxxxx. Your account administrator can activate STS in this region using the IAM Console."}
```

Pre-commit:
```
❯ uv run --with=pre-commit pre-commit run -a
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for merge conflicts................................................Passed
detect private key.......................................................Passed
detect aws credentials...................................................Passed
Terraform fmt............................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
Terraform validate.......................................................Passed
TruffleHog...............................................................Passed
```

File location for cleanup.sh:
```
❯ ls infra/aibrix/terraform/cleanup.sh
"infra/aibrix/terraform/cleanup.sh": No such file or directory (os error 2)

❯ ls infra/aibrix/terraform/_LOCAL/cleanup.sh
infra/aibrix/terraform/_LOCAL/cleanup.sh
```

<!-- Anything else we should know when reviewing? -->
