### PR TITLE
Update karpenter chart version from 1.4.0 to 1.6.3 in addons.tf

### DIFF
--- a/infra/base/terraform/addons.tf
+++ b/infra/base/terraform/addons.tf
@@ -102,7 +102,7 @@ module "eks_blueprints_addons" {
     }
   }
   karpenter = {
-    chart_version       = "1.4.0"
+    chart_version       = "1.6.3"
     repository_username = data.aws_ecrpublic_authorization_token.token.user_name
     repository_password = data.aws_ecrpublic_authorization_token.token.password
     source_policy_documents = [


### PR DESCRIPTION
### What does this PR do?

Update karpenter to chart version 1.6.3

<!-- A brief description of the change being made with this pull request. -->

### Motivation

It is getting hard to test with some instances and GPUs, so we have to rely on capacity blocks to be able to get some instances.

Created an initial nodepool and ec2nc for p5 and then edited to match the capacity block reservation I am able to apply to the cluster and use the instance from the reservation:
```
kubectl get ec2nodeclasses.karpenter.k8s.aws -n karpenter-resources g6-gpu-karpenter -o yaml | kubectl neat > p5-capacityblock-karpenter.yaml
kubectl get nodepools.karpenter.sh -n karpenter-resources g6-gpu-karpenter -o yaml | kubectl neat >> p5-capacityblock-karpenter.yaml
```

To use capacity blocks we need to upgrade Karpenter to at least v1.6 to support capacity blocks: [Utilizing On-Demand Capacity Reservations and Capacity Blocks](https://karpenter.sh/docs/tasks/odcrs/) 

> In [v1.6](https://github.com/aws/karpenter-provider-aws/releases/tag/v1.6.2), this support was expanded to include [EC2 Capacity Blocks for ML](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html). To enable native ODCR support, ensure the ReservedCapacity[ feature gate](https://karpenter.sh/docs/reference/settings/#feature-gates) is enabled.

Before the update, when trying to specify in the nodepool:
```
        - key: karpenter.k8s.aws/capacity-reservation-type
          operator: In
          values:
            - capacity-blocks
```

Got the error:
```
one or more objects failed to apply, reason: NodePool.karpenter.sh "p5-capacity-blocks-karpenter" is invalid: spec.template.spec.requirements[4].key: Invalid value: "string": label domain "karpenter.k8s.aws" is restricted
```

After upgrading to 1.6.3 the error was gone (due to CRD upgrade).

<!-- What inspired you to submit this pull request? -->

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Karpenter deploy succeeded:
```
❯ kubectl get deploy -n karpenter karpenter
NAME        READY   UP-TO-DATE   AVAILABLE   AGE
karpenter   2/2     2            2           95m

❯ kubectl get deploy -n karpenter -o yaml  | grep image:
          image: public.ecr.aws/karpenter/controller:1.6.3@sha256:b76551596698381c4940c15093afc733357b9ffffd5c97612d324b7a794aa0ed
```

pre-commit:
```
❯ uv run --with pre-commit pre-commit run -a
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for merge conflicts................................................Passed
detect private key.......................................................Passed
detect aws credentials...................................................Passed
Terraform fmt............................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
Terraform validate.......................................................Passed
TruffleHog...............................................................Passed
```