### PR TITLE
Fix nfd gc not being scheduable

### DIFF
--- a/infra/base/terraform/argocd-addons/nvidia-device-plugin.yaml
+++ b/infra/base/terraform/argocd-addons/nvidia-device-plugin.yaml
@@ -26,9 +26,6 @@ spec:
         # Configure Node Feature Discovery components
         nfd:
           enableNodeFeatureApi: true
-          gc:
-            nodeSelector:
-              karpenter.k8s.aws/instance-gpu-manufacturer: nvidia
           topologyUpdater:
             nodeSelector:
               karpenter.k8s.aws/instance-gpu-manufacturer: nvidia


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/ai-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

The NVIDIA device plugin have a node feature discovery (NFD) enabled, the garbage collector (GC) is not a DaemonSet (DS) but a Deployment that should run on a CPU node to report back to the NFD master.

By default the GC deployment will not tolerate GPU nodes which makes it not being able to schedule as we had a nodeSelector set for NVIDIA GPU

### Motivation

<!-- What inspired you to submit this pull request? -->
Make sure the NFD GC is running and the nvidia-device-plugin ArgoCD app is Healthy

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
