### PR TITLE
Fix installation script path in documentation

### DIFF
--- a/website/docs/blueprints/inference/GPUs/ray-vllm-deepseek.md
+++ b/website/docs/blueprints/inference/GPUs/ray-vllm-deepseek.md
@@ -74,7 +74,7 @@ For example, set your `export AWS_DEFAULT_REGION="<REGION>"` to the desired regi
 **Step2**: Run the installation script.
 
 ```bash
-cd ai-on-eks/infra/jark-stack/terraform && chmod +x install.sh
+cd ai-on-eks/infra/jark-stack && chmod +x install.sh
 ```
 
 ```bash


### PR DESCRIPTION
Resolves issues in #233 

```
└─[$] <> cd ai-on-eks/infra/jark-stack/terraform && chmod +x install.sh
chmod: install.sh: No such file or directory
```

### What does this PR do?

```
└─[$] <> cd ai-on-eks/infra/jark-stack && chmod +x install.sh 
└─[$] <git:(main*)> ./install.sh     
Initializing the backend...
Upgrading modules...
Downloading registry.terraform.io/terraform-aws-modules/eks-pod-identity/aws 2.5.0 for amp_ingest_pod_identity...
- amp_ingest_pod_identity in .terraform/modules/amp_ingest_pod_identity
- 
```
<!-- A brief description of the change being made with this pull request. -->

### Motivation

Reproducing Ray/vLLM with DeepSeek

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
