### PR TITLE
fix: update slinky-slurm nodeSelector to match Karpenter nodepool

### DIFF
--- a/blueprints/training/slinky-slurm/slurm-values.yaml.template
+++ b/blueprints/training/slinky-slurm/slurm-values.yaml.template
@@ -95,7 +95,7 @@ nodesets:
           mountPath: /dev/shm
     podSpec:
       nodeSelector:
-        instanceType: g5-gpu-karpenter
+        karpenter.sh/nodepool: g5-nvidia
         kubernetes.io/os: linux
       tolerations:
         - key: "nvidia.com/gpu"

--- a/website/docs/blueprints/training/GPUs/slinky-slurm.md
+++ b/website/docs/blueprints/training/GPUs/slinky-slurm.md
@@ -359,7 +359,7 @@ Make a new directory for your checkpoints
 mkdir -p checkpoints
 ```
 :::info
-By default the `llama2_7b-training.sbatch` batch training script is configured to distribute the FSDP workload across 4 nodes. The Slurm NodeSet maps to the `g5-gpu-karpenter` NodePool via a `NodeSelector.instanceType` value. If Karpenter is unable to find 4 on-demand or spot instances, you may need to make adjustment to the batch training script, then upload a new copy to your provisioned S3 bucket, which will sync it to the FSx for Lustre file system via a [data repository association](https://docs.aws.amazon.com/fsx/latest/LustreGuide/create-dra-linked-data-repo.html):
+By default the `llama2_7b-training.sbatch` batch training script is configured to distribute the FSDP workload across 4 nodes. The Slurm NodeSet maps to the `g5-nvidia` NodePool via the `karpenter.sh/nodepool` nodeSelector. If Karpenter is unable to find 4 on-demand or spot instances, you may need to make adjustment to the batch training script, then upload a new copy to your provisioned S3 bucket, which will sync it to the FSx for Lustre file system via a [data repository association](https://docs.aws.amazon.com/fsx/latest/LustreGuide/create-dra-linked-data-repo.html):
 ```
 cd ../../../infra/slinky-slurm/terraform/_LOCAL
 S3_BUCKET_NAME=$(terraform output -raw fsx_s3_bucket_name)


### PR DESCRIPTION
### What does this PR do?

Resolves #237. Fixes a regression where Slinky-Slurm GPU worker pods are stuck in Pending state because the `nodeSelector` references a non-existent Karpenter label.

**Changes:**
- `slurm-values.yaml.template`: Update `nodeSelector` from `instanceType: g5-gpu-karpenter` to `karpenter.sh/nodepool: g5-nvidia`
- `slinky-slurm.md`: Update documentation to reflect the correct NodePool name and label

### Motivation

After the Karpenter resources refactor in commit [62032996](https://github.com/awslabs/ai-on-eks/commit/62032996) (2025-10-17), the GPU NodePool was:
- Renamed from `g5-gpu-karpenter` to `g5-nvidia`
- Had the `instanceType` label removed (only `amiFamily` label remains in `nodepool.tpl`)

This broke the Slinky-Slurm blueprint - workers request `nodeSelector.instanceType: g5-gpu-karpenter` but Karpenter nodes don't have that label, so pods stay Pending indefinitely.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [x] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### Additional Notes

**Before (broken):** NodePool `g5-nvidia` only has `amiFamily: bottlerocket` label  
**Slurm template expected:** `instanceType: g5-gpu-karpenter` (doesn't exist)  
**Fix:** Use built-in `karpenter.sh/nodepool: g5-nvidia` label