### PR TITLE
fix: use PyTorch official Slurm approach for distributed training rendezvous

### DIFF
--- a/blueprints/training/slinky-slurm/llama2_7b-training.sbatch
+++ b/blueprints/training/slinky-slurm/llama2_7b-training.sbatch
@@ -78,12 +78,26 @@ echo "SLURM_JOB_NODELIST: $SLURM_JOB_NODELIST"
 echo "LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
 echo "======================="
 
+# Get the head node IP address using the official PyTorch Slurm approach
+# Reference: https://github.com/pytorch/examples/tree/main/distributed/ddp-tutorial-series/slurm
+# This bypasses hostname resolution issues in Slinky v0.4.x by using IP addresses directly
+nodes=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )
+nodes_array=($nodes)
+head_node=${nodes_array[0]}
+# Get the first IP address only (hostname may return multiple IPs separated by space)
+head_node_ip=$(srun --nodes=1 --ntasks=1 -w "$head_node" hostname --ip-address | awk '{print $1}')
+
+echo "=== Rendezvous Configuration ==="
+echo "Head node: $head_node"
+echo "Head node IP: $head_node_ip"
+echo "================================"
+
 declare -a TORCHRUN_ARGS=(
     --nproc_per_node=$GPUS_PER_NODE
     --nnodes=$SLURM_JOB_NUM_NODES
     --rdzv_id=$SLURM_JOB_ID
     --rdzv_backend=c10d
-    --rdzv_endpoint=$(hostname)
+    --rdzv_endpoint=${head_node_ip}:29500
 )
 
 export PATH="/usr/local/bin:$PATH"


### PR DESCRIPTION
### What does this PR do?

Resolves #240. Fixes multi-node distributed training in Slinky-Slurm by using the [official PyTorch Slurm approach](https://github.com/pytorch/examples/tree/main/distributed/ddp-tutorial-series/slurm) for rendezvous endpoint discovery. The previous implementation used `--rdzv_endpoint=$(hostname)` which fails because Slinky v0.4.x does not provide DNS resolution for worker pod hostnames.

The fix obtains the head node IP address directly using `srun hostname --ip-address`, bypassing hostname resolution entirely.

### Motivation

Multi-node distributed training jobs submitted via sbatch llama2_7b-training.sbatch fail with DNS resolution errors:

RendezvousConnectionError: TCP client failed to connect/validate to host slinky-0:29400 - Name or service not known

This is a known upstream issue: SlinkyProject/slurm-operator#51

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the website/docs or website/blog section for this feature
- [ ] Yes, I ran pre-commit run -a with this PR. Link for installing pre-commit locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

Tested on Slinky v0.4.1 with 4-node distributed training job. All nodes successfully connected via NCCL and training completed with exit code 0.

Rendezvous Configuration:
- Head node: slinky-3
- Head node IP: 100.64.137.203

Job Result:
- JobID: 11
- State: COMPLETED
- ExitCode: 0:0