### PR TITLE
Fix: exclude metrics-server and cloudwatch-observability addons for EKS Auto Mode

### DIFF
--- a/infra/base/terraform/eks.tf
+++ b/infra/base/terraform/eks.tf
@@ -8,6 +8,10 @@ locals {
   substr(cidr_block, 0, 4) == "100." ? subnet_id : null])
 
   # exclude addons for EKS Auto Mode as they are managed by EKS Auto Mode
+  # metrics-server: Auto Mode deploys it automatically as in-cluster pods
+  # amazon-cloudwatch-observability: not managed by Auto Mode, but excluded here to avoid
+  #   timeouts during cluster creation (no nodes available yet). Install it post-cluster
+  #   creation if needed: aws eks create-addon --cluster-name <name> --addon-name amazon-cloudwatch-observability
   auto_mode_exclude_addons = toset([
     "vpc-cni",
     "eks-pod-identity-agent",
@@ -15,6 +19,8 @@ locals {
     "coredns",
     "kube-proxy",
     "eks-node-monitoring-agent",
+    "metrics-server",
+    "amazon-cloudwatch-observability",
   ])
 
   base_addons = {

--- a/infra/base/terraform/eks.tf
+++ b/infra/base/terraform/eks.tf
@@ -8,10 +8,6 @@ locals {
   substr(cidr_block, 0, 4) == "100." ? subnet_id : null])
 
   # exclude addons for EKS Auto Mode as they are managed by EKS Auto Mode
-  # metrics-server: Auto Mode deploys it automatically as in-cluster pods
-  # amazon-cloudwatch-observability: not managed by Auto Mode, but excluded here to avoid
-  #   timeouts during cluster creation (no nodes available yet). Install it post-cluster
-  #   creation if needed: aws eks create-addon --cluster-name <name> --addon-name amazon-cloudwatch-observability
   auto_mode_exclude_addons = toset([
     "vpc-cni",
     "eks-pod-identity-agent",

--- a/infra/base/terraform/eks.tf
+++ b/infra/base/terraform/eks.tf
@@ -8,6 +8,10 @@ locals {
   substr(cidr_block, 0, 4) == "100." ? subnet_id : null])
 
   # exclude addons for EKS Auto Mode as they are managed by EKS Auto Mode
+  # metrics-server: Auto Mode deploys it automatically as in-cluster pods
+  # amazon-cloudwatch-observability: not managed by Auto Mode, but excluded here to avoid
+  #   timeouts during cluster creation (no nodes available yet). Install it post-cluster
+  #   creation if needed: aws eks create-addon --cluster-name <name> --addon-name amazon-cloudwatch-observability
   auto_mode_exclude_addons = toset([
     "vpc-cni",
     "eks-pod-identity-agent",


### PR DESCRIPTION
### What does this PR do?

Adds metrics-server and amazon-cloudwatch-observability to the auto_mode_exclude_addons list in eks.tf.

After PR #288, these two addons were not excluded for Auto Mode, causing Terraform to hang during module.eks apply — no nodes are available to schedule addon pods during cluster creation.

metrics-server: Auto Mode already provides it natively
amazon-cloudwatch-observability: Needs running nodes, which don't exist yet during module.eks phase. Can be installed post-creation if needed.
Non-Auto-Mode (Karpenter) deployments are not affected.

### Motivation

Fixes (https://github.com/awslabs/ai-on-eks/issues/302) — EKS Auto Mode deployments timeout during cluster creation on metrics-server and amazon-cloudwatch-observability addon installation.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
