### PR TITLE
fix: Add configurable AMP Grafana plugin version to prevent breaking changes

### DIFF
--- a/infra/base/terraform/helm-values/kube-prometheus-amp-enable.yaml
+++ b/infra/base/terraform/helm-values/kube-prometheus-amp-enable.yaml
@@ -64,7 +64,7 @@ grafana:
     datasources:
       defaultDatasourceEnabled: false
   plugins:
-    - grafana-amazonprometheus-datasource
+    - grafana-amazonprometheus-datasource${amp_plugin_version != "" ? " ${amp_plugin_version}" : ""}
   additionalDataSources:
     - name: Amazon-Managed-Prometheus
       type: grafana-amazonprometheus-datasource

--- a/infra/base/terraform/kube-prometheus-stack.tf
+++ b/infra/base/terraform/kube-prometheus-stack.tf
@@ -12,6 +12,7 @@ locals {
     amp_remotewrite_url  = "https://aps-workspaces.${local.region}.amazonaws.com/workspaces/${aws_prometheus_workspace.amp[0].id}/api/v1/remote_write"
     amp_url              = "https://aps-workspaces.${local.region}.amazonaws.com/workspaces/${aws_prometheus_workspace.amp[0].id}"
     grafana_service_port = var.grafana_service_port
+    amp_plugin_version   = var.grafana_amp_plugin_version
   }) : ""
 
   # Merge base and AMP values

--- a/infra/base/terraform/variables.tf
+++ b/infra/base/terraform/variables.tf
@@ -186,6 +186,11 @@ variable "grafana_operator_version" {
   type        = string
   default     = "5.16.0"
 }
+variable "grafana_amp_plugin_version" {
+  description = "Amazon Managed Prometheus Grafana plugin version. Leave empty to install latest."
+  type        = string
+  default     = "2.3.2"
+}
 variable "grafana_service_port" {
   description = "Grafana service port"
   type        = number

--- a/infra/base/terraform/variables.tf
+++ b/infra/base/terraform/variables.tf
@@ -189,7 +189,7 @@ variable "grafana_operator_version" {
 variable "grafana_amp_plugin_version" {
   description = "Amazon Managed Prometheus Grafana plugin version. Leave empty to install latest."
   type        = string
-  default     = "2.3.2"
+  default     = ""
 }
 variable "grafana_service_port" {
   description = "Grafana service port"

--- a/infra/workshops/genai-on-eks/terraform/blueprint.tfvars
+++ b/infra/workshops/genai-on-eks/terraform/blueprint.tfvars
@@ -26,6 +26,7 @@ enable_amazon_prometheus        = true
 enable_nvidia_dcgm_exporter     = false
 kube_prometheus_stack_namespace = "monitoring"
 grafana_service_port            = 3000
+grafana_amp_plugin_version      = "2.3.2"
 grafana_admin_password          = "notforproductionuse"
 
 ################################################################################


### PR DESCRIPTION
### Description:

The grafana-amazonprometheus-datasource plugin v2.4.0 (released after March 2nd) introduced a dependency on promlib from @grafana/grafana-prometheus-datasource, which is only available in Grafana 12.x. Since the genai-on-eks workshop runs Grafana 11.5.2, the plugin's frontend module fails to load with:

Error: 404 Not Found, loading react/jsx-runtime from module.js (SystemJS Error#7)
The plugin was previously unpinned (grafana-amazonprometheus-datasource with no version), so every Grafana pod restart pulled the latest version via GF_INSTALL_PLUGINS. When v2.4.0 was released upstream, it silently broke the AMP datasource — the settings page shows "Type: undefined" and no configuration options render.

### Changes:

Added grafana_amp_plugin_version variable to variables.tf (defaults to "" for latest)
Made the plugin version configurable in the Helm values template via templatefile
Pinned the workshop's blueprint.tfvars to 2.3.2 (last version compatible with Grafana 11.x)