### PR TITLE
 VPC Networking Improvements 

### DIFF
--- a/infra/base/terraform/efs.tf
+++ b/infra/base/terraform/efs.tf
@@ -15,7 +15,8 @@ module "efs" {
   throughput_mode = "elastic"
   # Mount targets / security group
   mount_targets = {
-    for k, v in zipmap(local.azs, slice(module.vpc.private_subnets, length(module.vpc.private_subnets) - var.availability_zones_count, length(module.vpc.private_subnets))) : k => { subnet_id = v }
+    for k, v in zipmap(local.azs, slice(module.vpc.private_subnets, length(module.vpc.private_subnets) - local.azs_count, length(module.vpc.private_subnets))) : k => { subnet_id = v }
+    if alltrue([for az in local.local_azs : k != az])
   }
 
   security_group_name        = "${local.name}-efs"

--- a/infra/base/terraform/eks.tf
+++ b/infra/base/terraform/eks.tf
@@ -3,6 +3,15 @@
 #---------------------------------------
 
 locals {
+  # exclude zones where EKS control plane can't reside in: https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html#network-requirements-subnets
+  cp_excluded_az_ids = ["use1-az3", "usw1-az2", "cac1-az3"]
+  # EKS control plane subnets, exclude zones where EKS control plane can't reside in and local zones
+  cp_subnets = [
+    for s in module.vpc.intra_subnet_objects : s.id
+    if alltrue([for az in local.cp_excluded_az_ids : s.availability_zone_id != az]) &&
+    alltrue([for az in local.local_azs : s.availability_zone != az])
+  ]
+
   # Filter secondary CIDR subnets (starting with "100.")
   secondary_cidr_subnets = compact([for subnet_id, cidr_block in zipmap(module.vpc.private_subnets, module.vpc.private_subnets_cidr_blocks) :
   substr(cidr_block, 0, 4) == "100." ? subnet_id : null])
@@ -63,9 +72,8 @@ module "eks" {
 
   vpc_id = module.vpc.vpc_id
 
-  # Filtering only Secondary CIDR private subnets starting with "100.".
   # Subnet IDs where the EKS Control Plane ENIs will be created
-  subnet_ids = local.secondary_cidr_subnets
+  control_plane_subnet_ids = local.cp_subnets
 
   # Combine root account, current user/role and additional roles to be able to access the cluster KMS key - required for terraform updates
   kms_key_administrators = distinct(concat([

--- a/infra/base/terraform/main.tf
+++ b/infra/base/terraform/main.tf
@@ -34,8 +34,6 @@ data "aws_eks_cluster_auth" "this" {
   name = module.eks.cluster_name
 }
 
-data "aws_availability_zones" "available" {}
-
 data "aws_ecrpublic_authorization_token" "token" {
   region = "us-east-1"
 }
@@ -48,8 +46,6 @@ data "aws_iam_session_context" "current" {
 
 locals {
   name                   = var.name
-  region                 = var.region
-  azs                    = slice(data.aws_availability_zones.available.names, 0, var.availability_zones_count)
   partition              = data.aws_partition.current.partition
   account_id             = data.aws_caller_identity.current.account_id
   mlflow_name            = "mlflow"

--- a/infra/base/terraform/variables.tf
+++ b/infra/base/terraform/variables.tf
@@ -36,8 +36,8 @@ variable "solution_id" {
 
 # VPC with configurable AZs - CIDR size should match AZ count
 variable "vpc_cidr" {
-  description = "VPC CIDR. This should be a valid private (RFC 1918) CIDR range. Recommended: /21 for 2 AZs, /20 for 3 AZs, /19 for 4 AZs. If the network prefix is not provided, it will be computed"
-  default     = "10.1.0.0"
+  description = "VPC CIDR. This should be a valid private (RFC 1918) CIDR range. Recommended to use a /16 CIDR"
+  default     = "10.0.0.0/16"
   type        = string
 }
 
@@ -46,9 +46,33 @@ variable "availability_zones_count" {
   type        = number
   default     = 2
   validation {
-    condition     = var.availability_zones_count >= 2 && var.availability_zones_count <= 4
-    error_message = "The availability_zones_count must be between 2 and 4."
+    condition     = var.availability_zones_count >= 2 && var.availability_zones_count <= 6
+    error_message = "The availability_zones_count must be between 2 and 6."
   }
+}
+
+variable "local_zones_count" {
+  description = "Number of local zones to use for the deployment"
+  type        = number
+  default     = 0
+}
+
+variable "private_subnets_cidr_prefix" {
+  description = "CIDR prefix for the private subnets"
+  type        = number
+  default     = 24
+}
+
+variable "public_subnets_cidr_prefix" {
+  description = "CIDR prefix for the public subnets"
+  type        = number
+  default     = 24
+}
+
+variable "control_plane_subnets_cidr_prefix" {
+  description = "CIDR prefix for the control plane subnets"
+  type        = number
+  default     = 26
 }
 
 variable "single_nat_gateway" {
@@ -58,10 +82,10 @@ variable "single_nat_gateway" {
 }
 
 # RFC6598 range 100.64.0.0/10
-# Note you can only /16 range to VPC. You can add multiples of /16 if required
+# Note you can only add /16 range to VPC. You can add multiples of /16 if required
 variable "secondary_cidr_blocks" {
   description = "Secondary CIDR blocks to be attached to VPC"
-  default     = ["100.64.0.0/16"]
+  default     = ["100.64.0.0/16", "100.65.0.0/16", "100.66.0.0/16", "100.67.0.0/16"]
   type        = list(string)
 }
 
@@ -69,6 +93,12 @@ variable "enable_database_subnets" {
   description = "Whether or not to enable the database subnets"
   type        = bool
   default     = false
+}
+
+variable "database_subnets_cidr_prefix" {
+  description = "CIDR prefix for the database subnets"
+  type        = number
+  default     = 24
 }
 
 variable "enable_eks_auto_mode" {

--- a/infra/base/terraform/vpc.tf
+++ b/infra/base/terraform/vpc.tf
@@ -1,45 +1,72 @@
-locals {
-  # Calculate CIDR range if not specified. Check if var.vpc_cidr has subnet mask, if not add one based on the following table
-  cidr_bits = tomap({
-    4 = "19"
-    3 = "20"
-    2 = "21"
-  })
-  vpc_cidr = strcontains(var.vpc_cidr, "/") ? var.vpc_cidr : format("%s/%s", var.vpc_cidr, local.cidr_bits[var.availability_zones_count])
-
-  # Calculate subnet sizes based on number of AZs to avoid overlaps
-  # We need to allocate space for: private subnets, public subnets, and database subnets
-  # Strategy: Divide VPC CIDR into equal blocks for each subnet type
-
-  # Calculate the subnet size needed based on AZ count
-  # For 2 AZs: /24 subnets (256 IPs each)
-  # For 3 AZs: /25 subnets (128 IPs each)
-  # For 4 AZs: /26 subnets (64 IPs each)
-  subnet_newbits = var.availability_zones_count == 2 ? 3 : var.availability_zones_count == 3 ? 4 : 5
-
-  # Private subnets: Start from index 0
-  # e.g., 10.1.0.0/21 with 2 AZs => ["10.1.0.0/24", "10.1.1.0/24"]
-  # e.g., 10.1.0.0/20 with 3 AZs => ["10.1.0.0/25", "10.1.0.128/25", "10.1.1.0/25"]
-  private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, local.subnet_newbits, k)]
-
-  # Public subnets: Start after private subnets
-  # e.g., 10.1.0.0/21 with 2 AZs => ["10.1.2.0/24", "10.1.3.0/24"]
-  # e.g., 10.1.0.0/20 with 3 AZs => ["10.1.1.128/25", "10.1.2.0/25", "10.1.2.128/25"]
-  public_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, local.subnet_newbits, k + var.availability_zones_count)]
-
-  # Database subnets: Start after public subnets
-  # e.g., 10.1.0.0/21 with 2 AZs => ["10.1.4.0/24", "10.1.5.0/24"]
-  # e.g., 10.1.0.0/20 with 3 AZs => ["10.1.3.0/25", "10.1.3.128/25", "10.1.4.0/25"]
-  database_private_subnets = var.enable_database_subnets ? [for k, v in local.azs : cidrsubnet(local.vpc_cidr, local.subnet_newbits, k + (2 * var.availability_zones_count))] : []
-
-  # RFC6598 range 100.64.0.0/16 for EKS Data Plane subnets across configurable AZs
-  # Divide the secondary CIDR equally among AZs
-  # For 2 AZs: /17 subnets (32768 IPs each)
-  # For 3 AZs: /18 subnets (16384 IPs each)
-  # For 4 AZs: /18 subnets (16384 IPs each) - using only 4 of 4 possible /18 subnets
-  secondary_newbits                  = var.availability_zones_count <= 2 ? 1 : 2
-  secondary_ip_range_private_subnets = [for k, v in local.azs : cidrsubnet(element(var.secondary_cidr_blocks, 0), local.secondary_newbits, k)]
+data "aws_availability_zones" "available" {
+  # only use zones that are availability-zones (e.g: exclude local and wavelength zones)
+  filter {
+    name   = "zone-type"
+    values = ["availability-zone"]
+  }
 }
+
+data "aws_availability_zones" "available_lz" {
+  # local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opted-in"]
+  }
+  filter {
+    name   = "zone-type"
+    values = ["local-zone"]
+  }
+}
+
+locals {
+  region    = var.region
+  local_azs = slice(data.aws_availability_zones.available_lz.names, 0, var.local_zones_count)
+  az_azs    = slice(data.aws_availability_zones.available.names, 0, var.availability_zones_count)
+
+  # concat to put local zones at the end of the list to avoid creation on NAT Gateway
+  azs       = concat(local.az_azs, local.local_azs)
+  azs_count = var.availability_zones_count + var.local_zones_count
+
+  vpc_cidr        = var.vpc_cidr
+  vpc_cidr_prefix = tonumber(split("/", local.vpc_cidr)[1])
+
+  private_subnets          = [for k, v in module.subnets.network_cidr_blocks : v if endswith(k, "/private")]
+  public_subnets           = [for k, v in module.subnets.network_cidr_blocks : v if endswith(k, "/public")]
+  control_plane_subnets    = [for k, v in module.subnets.network_cidr_blocks : v if endswith(k, "/cp")]
+  database_private_subnets = var.enable_database_subnets ? [for k, v in module.subnets.network_cidr_blocks : v if endswith(k, "/database")] : []
+
+  # Subnet sizing: newbits determines how many subnets fit per secondary CIDR block (/16 CIDR prefix)
+  # 1 - 2 /17 subnets (32763 IPs each)
+  # 2 - 4 /18 subnets (16379 IPs each)
+  # 3 - 8 /19 subnets (8187 IPs each)
+  secondary_newbits = 1
+
+  # Max subnets that fit in one CIDR block given the newbits
+  secondary_subnets_per_cidr = pow(2, local.secondary_newbits)
+
+  # For each AZ, pick the CIDR block (first one until full, then overflow to next) and compute the subnet index within that block
+  secondary_ip_range_private_subnets = [
+    for k, v in local.azs : cidrsubnet(
+      var.secondary_cidr_blocks[floor(k / local.secondary_subnets_per_cidr)],
+      local.secondary_newbits,
+      k % local.secondary_subnets_per_cidr
+    )
+  ]
+}
+
+module "subnets" {
+  source  = "hashicorp/subnets/cidr"
+  version = "1.0.0"
+
+  base_cidr_block = var.vpc_cidr
+  networks = concat(
+    [for k, v in local.azs : tomap({ "name" = "${v}/public", "new_bits" = var.public_subnets_cidr_prefix - local.vpc_cidr_prefix })],
+    [for k, v in local.azs : tomap({ "name" = "${v}/private", "new_bits" = var.private_subnets_cidr_prefix - local.vpc_cidr_prefix })],
+    [for k, v in local.azs : tomap({ "name" = "${v}/cp", "new_bits" = var.control_plane_subnets_cidr_prefix - local.vpc_cidr_prefix })],
+    var.enable_database_subnets ? [for k, v in local.azs : tomap({ "name" = "${v}/database", "new_bits" = var.database_subnets_cidr_prefix - local.vpc_cidr_prefix })] : []
+  )
+}
+
 
 #---------------------------------------------------------------
 # VPC
@@ -61,6 +88,9 @@ module "vpc" {
   # 1/ EKS Data Plane secondary CIDR blocks for subnets across configurable AZs for EKS Control Plane ENI + Nodes + Pods
   # 2/ Private Subnets with RFC1918 private IPv4 address range for Private NAT + NLB + Airflow + EC2 Jumphost etc.
   private_subnets = concat(local.private_subnets, local.secondary_ip_range_private_subnets)
+
+  # EKS Control Plane subnets
+  intra_subnets = local.control_plane_subnets
 
   # ------------------------------
   # Private Subnets for MLflow backend store


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/ai-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

Overhauls the VPC networking layer to support larger-scale deployments
1. Avoid issues where local zones was opted-in, now local zones support can be configurable if wanted.
2. Configurable subnet CIDR prefixes per type
3. Separate EKS control plane subnets with support to exclude AZs where EKS control plane is not available, this allows as example to use all AZs in us-east-1.
4. Support for multiple secondary CIDR blocks for data plane (worker nodes)

## Changes

### `vpc.tf` — Complete subnet calculation rewrite

- Replaced hardcoded `cidrsubnet` math with the [`hashicorp/subnets/cidr`](https://registry.terraform.io/modules/hashicorp/subnets/cidr/latest) module for deterministic, collision-free subnet allocation
- Added `data "aws_availability_zones"` lookups for both standard AZs and opted-in local zones
- Added dedicated EKS control plane (`intra_subnets`) subnet tier
- Secondary CIDR subnets now span across multiple `/16` blocks automatically — when one fills up it overflows to the next, enabling support for 6+ AZs

### `variables.tf` — New variables

| Variable | Default | Description |
|----------|---------|-------------|
| `local_zones_count` | `0` | Number of local zones to include |
| `private_subnets_cidr_prefix` | `24` | Configurable private subnet size |
| `public_subnets_cidr_prefix` | `24` | Configurable public subnet size |
| `control_plane_subnets_cidr_prefix` | `26` | Dedicated control plane subnet size |
| `database_subnets_cidr_prefix` | `24` | Configurable database subnet size |

**Changed defaults:**

| Variable | Before | After |
|----------|--------|-------|
| `secondary_cidr_blocks` | `["100.64.0.0/16"]` | `["100.64.0.0/16", "100.65.0.0/16", "100.66.0.0/16", "100.67.0.0/16"]` |
| `availability_zones_count` validation | `2–4` | `2–6` |
| `vpc_cidr` | `"10.1.0.0"` (auto-computed prefix) | `"10.0.0.0/16"` (explicit `/16`) |

### Motivation

<!-- What inspired you to submit this pull request? -->
Support for local zones, separate EKS control plane from worker node subnets to support all AZs.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
