### PR TITLE
fix: shorten IAM name_prefix values to support longer cluster names

### DIFF
--- a/infra/base/terraform/s3.tf
+++ b/infra/base/terraform/s3.tf
@@ -69,7 +69,7 @@ resource "aws_s3_bucket_public_access_block" "models_bucket_pab" {
 resource "aws_iam_role" "model_sync_role" {
   count = var.enable_s3_models_storage ? 1 : 0
 
-  name_prefix = "${local.name}-model-sync-role-"
+  name_prefix = "${local.name}-mdl-sync-"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -97,7 +97,7 @@ resource "aws_iam_role" "model_sync_role" {
 resource "aws_iam_policy" "model_sync_policy" {
   count = var.enable_s3_models_storage ? 1 : 0
 
-  name_prefix = "${local.name}-model-sync-policy-"
+  name_prefix = "${local.name}-mdl-sync-pol-"
   description = "Policy for S3 model upload operations"
 
   policy = jsonencode({
@@ -134,7 +134,7 @@ resource "aws_iam_role_policy_attachment" "model_sync_policy_attachment" {
 resource "aws_iam_role" "model_inference_role" {
   count = var.enable_s3_models_storage ? 1 : 0
 
-  name_prefix = "${local.name}-model-inference-role-"
+  name_prefix = "${local.name}-mdl-infer-"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -162,7 +162,7 @@ resource "aws_iam_role" "model_inference_role" {
 resource "aws_iam_policy" "model_inference_policy" {
   count = var.enable_s3_models_storage ? 1 : 0
 
-  name_prefix = "${local.name}-model-inference-policy-"
+  name_prefix = "${local.name}-mdl-infer-pol-"
   description = "Policy for S3 model inference operations (read-only)"
 
   policy = jsonencode({


### PR DESCRIPTION
## Problem

The `name_prefix` attribute on `aws_iam_role` and `aws_iam_policy` resources in `s3.tf` has a maximum length of 38 characters. When `local.name` exceeds ~16 characters (e.g. `genai-workshop-dz`), the generated prefix like `genai-workshop-dz-model-inference-role-` (39 chars) exceeds this limit and Terraform fails with:

```
Error: expected length of name_prefix to be in the range (1 - 38)
```

## Solution

Shortened the IAM `name_prefix` suffixes to stay well under the 38-char limit:

| Resource | Before | After |
|----------|--------|-------|
| model_sync_role | `-model-sync-role-` | `-mdl-sync-` |
| model_sync_policy | `-model-sync-policy-` | `-mdl-sync-pol-` |
| model_inference_role | `-model-inference-role-` | `-mdl-infer-` |
| model_inference_policy | `-model-inference-policy-` | `-mdl-infer-pol-` |

The descriptive `tags` on each resource remain unchanged, so readability in the AWS console is preserved.

## Testing

Deployed an EKS cluster with `name = "genai-workshop-dz"` (18 chars) successfully after this change.
