### PR TITLE
fix: drain nodes before terraform destroy to prevent degraded nodes during teardown

### DIFF
--- a/infra/base/terraform/cleanup.sh
+++ b/infra/base/terraform/cleanup.sh
@@ -29,6 +29,28 @@ else
 fi
 
 
+# Drain nodes before terraform destroy. Terraform deletes VPC routes concurrently
+# with EKS cluster deletion, which can strand nodes without network connectivity.
+echo "Draining nodes before terraform destroy..."
+if [[ ! $(cat $TMPFILE) == *"No outputs found"* ]]; then
+  # For Auto Mode clusters: disable built-in nodepools via EKS API
+  AUTOMODE=$(terraform output -raw enable_eks_auto_mode 2>/dev/null || echo "false")
+  if [[ "$AUTOMODE" == "true" ]]; then
+    echo "Disabling built-in nodepools via EKS API..."
+    aws eks update-cluster-config \
+      --name "$CLUSTERNAME" \
+      --region "$REGION" \
+      --compute-config '{"enabled":true,"nodePools":[]}' || echo "WARNING: Failed to disable built-in nodepools"
+    echo "Waiting for cluster update to complete..."
+    aws eks wait cluster-active --name "$CLUSTERNAME" --region "$REGION" || echo "WARNING: Wait timed out"
+  fi
+
+  # Delete all nodepools (covers both Karpenter and any remaining Auto Mode pools)
+  echo "Deleting all nodepools..."
+  kubectl delete nodepool --all --wait=true --timeout=300s 2>/dev/null || echo "WARNING: No nodepools found or delete failed"
+  echo "Node drain complete"
+fi
+
 # List of Terraform modules to destroy in sequence
 targets=($(terraform state list | grep "kubectl_manifest\." | grep -v "kubectl_manifest.aws_load_balancer_controller"))
 


### PR DESCRIPTION
### What does this PR do?

Fixes a race condition in the cluster teardown sequence where VPC networking infrastructure (routes, NAT gateways) is destroyed while nodes are still running, leaving them in a degraded state with no network connectivity.

Changes:
- `infra/base/terraform/cleanup.sh`: Before running `terraform destroy`, disable built-in EKS Auto Mode nodepools via `aws eks update-cluster-config` (setting `nodePools` to `[]`), then delete any remaining nodepools via `kubectl delete nodepool --all --wait=true`. This ensures all nodes are fully terminated before VPC teardown begins.

### Motivation

During cluster deletion, `terraform destroy` deletes VPC route table entries concurrently with EKS cluster deletion. The clusters take several minutes to fully delete, but routes are removed instantly — so nodes lose outbound connectivity to the control plane and go degraded in the interim.

This happens because Terraform only infers dependency from explicit resource references. The EKS cluster references VPC subnets, so subnets wait. But routes, NAT gateways, and route table associations have no such reference, so they get torn down immediately.

The existing `wait = true` on `kubectl_manifest` resources blocks Terraform on *that resource's* deletion, but doesn't prevent VPC resources from being destroyed concurrently — they run in parallel since there's no dependency edge between them.

This fix drains all nodes *before* `terraform destroy` starts:
1. For Auto Mode clusters: disables built-in nodepools via the EKS API per [AWS docs](https://docs.aws.amazon.com/eks/latest/userguide/set-builtin-node-pools.html)
2. Deletes any remaining nodepools via `kubectl delete nodepool --all --wait=true`
3. Only then proceeds with `terraform destroy`

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

Tested end-to-end: deployed an Auto Mode cluster, confirmed nodes were running, ran the fixed cleanup, and verified no degraded nodes appeared during the teardown window. Not a new blueprint — single file change to `infra/base/terraform/cleanup.sh`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.