### PR TITLE
Disable HuggingFace XET in model download job

### DIFF
--- a/infra/workshops/genai-on-eks/terraform/pull.tf
+++ b/infra/workshops/genai-on-eks/terraform/pull.tf
@@ -54,6 +54,9 @@ resource "kubectl_manifest" "mistral_model_download" {
 
               print("Upload complete!")
               EOF
+            env:
+            - name: HF_HUB_DISABLE_XET
+              value: "1"
             resources:
               requests:
                 memory: "4Gi"


### PR DESCRIPTION
### What does this PR do?

Adds HF_HUB_DISABLE_XET=1 environment variable to the model download job to prevent XET transport errors during model pulls from HuggingFace.


🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/ai-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
