### PR TITLE
fix(terraform): enable inline IAM policy for Karpenter to support lo…

### DIFF
--- a/infra/base/terraform/karpenter.tf
+++ b/infra/base/terraform/karpenter.tf
@@ -12,6 +12,9 @@ module "karpenter" {
   node_iam_role_name              = "karpenterNode-${local.name}"
   create_pod_identity_association = true
 
+  # Managed policy exceeds 6144 chars for longer cluster names; inline allows 10240
+  enable_inline_policy = true
+
   # Used to attach additional IAM policies to the Karpenter node IAM role
   node_iam_role_additional_policies = {
     AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"


### PR DESCRIPTION
Added `enable_inline_policy` to the Karpenter Terraform module so the controller IAM policy can exceed the 6,144-character managed-policy limit, which is required for longer cluster names (for example `inference-cluster`). This follows the [terraform-aws-eks workaround](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3512) and uses inline role policies (10,240-character limit) instead of a standalone managed policy.

### What does this PR do?

Sets `enable_inline_policy = true` on the shared `module "karpenter"` in `infra/base/terraform/karpenter.tf`.

Without this, `terraform apply` can fail when creating the Karpenter controller IAM policy:

```text
LimitExceeded: Cannot exceed quota for PolicySize: 6144
```

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Before fix:
```
╷
│ Error: creating IAM Policy (KarpenterController-20260525094322854700000009): operation error IAM: CreatePolicy, https response error StatusCode: 409, RequestID: 505a6c3b-3fd3-4fb6-a188-6ef4cd01377e, LimitExceeded: Cannot exceed quota for PolicySize: 6144
│ 
│   with module.karpenter[0].aws_iam_policy.controller[0],
│   on .terraform/modules/karpenter/modules/karpenter/main.tf line 82, in resource "aws_iam_policy" "controller":
│   82: resource "aws_iam_policy" "controller" {
│ 
╵
FAILED: Terraform apply of module.karpenter failed
```

After fix:
```
Apply complete! Resources: 42 added, 0 changed, 0 destroyed.

Outputs:

configure_kubectl = "aws eks --region us-west-2 update-kubeconfig --name inference-cluster"
deployment_name = "inference-cluster"
SUCCESS: Terraform apply of all modules completed successfully
```


pre-commit tests:
```
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for merge conflicts................................................Passed
detect private key.......................................................Passed
detect aws credentials...................................................Passed
Terraform fmt............................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
Terraform validate.......................................................Passed
TruffleHog...............................................................Passed
```