### PR TITLE
update-workshop-banner

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -25,5 +25,5 @@ jobs:
           repo: terraform-docs/terraform-docs
           tag: v0.20.0
       - name: install trufflehog
-        run: curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/f37f2eff68c31620fd88bc37ff2b7d57ea0c700c/scripts/install.sh | sh -s -- -b /usr/local/bin
+        run: curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/37b77001d0174ebec2fcca2bd83ff83a6d45a3ab/scripts/install.sh | sh -s -- -b /usr/local/bin v3.95.3
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -65,7 +65,7 @@ const config = {
             announcementBar: {
                 id: 'genai-workshop-banner',
                 content:
-                    'GenAI on EKS workshop series! <a target="_blank" rel="noopener noreferrer" href="https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=9be4af2e-2339-40ae-b5e9-57b6a7704c36&sc_channel=el" style="color: #ffffff; text-decoration: underline; font-weight: bold; margin-left: 10px;">Register now →</a>',
+                    'GenAI on EKS workshop series! <a target="_blank" rel="noopener noreferrer" href="https://events.eksworkshop.com/workshops/genai/" style="color: #ffffff; text-decoration: underline; font-weight: bold; margin-left: 10px;">Register now →</a>',
                 backgroundColor: '#667eea',
                 textColor: '#ffffff',
                 isCloseable: true,


### PR DESCRIPTION
### What does this PR do?

1. Updates the GenAI workshop banner link in the Docusaurus website config from the old aws-experience.com URL to the new events.eksworkshop.com/workshops/genai/ URL.
2. Fixes CI failure in pre-commit.yaml by pinning TruffleHog to v3.95.3. The latest release (v3.95.4) has missing binaries causing a 404 during install.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

* The old workshop registration link is outdated. This updates it to point to the current workshop page.
* The TruffleHog v3.95.4 release is missing platform binaries, breaking CI for all PRs. Pinning to v3.95.3 restores CI functionality.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [x] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
* Verified TruffleHog v3.95.3 installs successfully with pinned version tag.
* The CI was failing for all PRs due to an upstream TruffleHog release issue (v3.95.4 published without full binaries). Fix pins the version explicitly to prevent future breakage from incomplete upstream releases.
