### PR TITLE
unblock regions that don't support S3 Express and previous generation…

### DIFF
--- a/infra/base/terraform/eks.tf
+++ b/infra/base/terraform/eks.tf
@@ -188,7 +188,7 @@ module "eks" {
       max_size     = 8
       desired_size = 2
 
-      instance_types = ["m6i.xlarge"]
+      instance_types = ["m6i.xlarge", "m7i.xlarge"]
 
       labels = {
         WorkerType    = "ON_DEMAND"

--- a/infra/base/terraform/vpc.tf
+++ b/infra/base/terraform/vpc.tf
@@ -132,30 +132,49 @@ module "vpc" {
 # VPC Endpoints
 ################################################################################
 
+# Regions where S3 Express One Zone (and its Gateway VPC endpoint) is available.
+# Reference: https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-Regions-and-Zones.html
+locals {
+  s3express_supported_regions = [
+    "us-east-1",
+    "us-east-2",
+    "us-west-2",
+    "ap-south-1",
+    "ap-northeast-1",
+    "eu-west-1",
+    "eu-north-1",
+  ]
+  s3express_available = contains(local.s3express_supported_regions, local.region)
+}
+
 module "vpc_endpoints" {
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
   version = "~> 6.4"
 
   vpc_id = module.vpc.vpc_id
 
-  endpoints = {
-    s3 = {
-      service         = "s3"
-      service_type    = "Gateway"
-      route_table_ids = module.vpc.private_route_table_ids
-      tags = {
-        Name = "${var.name}-s3-vpc-endpoint"
+  endpoints = merge(
+    {
+      s3 = {
+        service         = "s3"
+        service_type    = "Gateway"
+        route_table_ids = module.vpc.private_route_table_ids
+        tags = {
+          Name = "${var.name}-s3-vpc-endpoint"
+        }
       }
-    }
-    s3express = {
-      service         = "s3express"
-      service_type    = "Gateway"
-      route_table_ids = module.vpc.private_route_table_ids
-      tags = {
-        Name = "${var.name}-s3express-vpc-endpoint"
+    },
+    local.s3express_available ? {
+      s3express = {
+        service         = "s3express"
+        service_type    = "Gateway"
+        route_table_ids = module.vpc.private_route_table_ids
+        tags = {
+          Name = "${var.name}-s3express-vpc-endpoint"
+        }
       }
-    }
-  }
+    } : {}
+  )
 
   tags = local.tags
 }


### PR DESCRIPTION
… instance types

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/ai-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

* Only apply S3 Express Zone VPC Endpoints on supported regions
* Add extra instance type for the core MNG

### Motivation

<!-- What inspired you to submit this pull request? -->

Unblock regions such as eu-south-2.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
