### PR TITLE
Add Karpenter reserved capacity support and Kimi K3 recipe

### DIFF
--- a/infra/base/terraform/argocd-addons/leader-worker-set.yaml
+++ b/infra/base/terraform/argocd-addons/leader-worker-set.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kubernetes-sigs/lws.git
-    targetRevision: v0.7.0
+    targetRevision: ${version}
     path: config/default
   destination:
     server: https://kubernetes.default.svc

--- a/infra/base/terraform/argocd_addons.tf
+++ b/infra/base/terraform/argocd_addons.tf
@@ -82,7 +82,7 @@ resource "kubectl_manifest" "envoy_gateway_yaml" {
 
 resource "kubectl_manifest" "lws_yaml" {
   count     = var.enable_leader_worker_set ? 1 : 0
-  yaml_body = file("${path.module}/argocd-addons/leader-worker-set.yaml")
+  yaml_body = templatefile("${path.module}/argocd-addons/leader-worker-set.yaml", { version = var.leader_worker_set_version })
 
   depends_on = [
     helm_release.argocd

--- a/infra/base/terraform/helm-values/kube-prometheus.yaml
+++ b/infra/base/terraform/helm-values/kube-prometheus.yaml
@@ -169,7 +169,7 @@ grafana:
   dashboards:
     default:
       capacity-dashboard:
-        url: https://karpenter.sh/v1.11/getting-started/getting-started-with-karpenter/karpenter-capacity-dashboard.json
+        url: https://karpenter.sh/v1.14/getting-started/getting-started-with-karpenter/karpenter-capacity-dashboard.json
       performance-dashboard:
-        url: https://karpenter.sh/v1.11/getting-started/getting-started-with-karpenter/karpenter-performance-dashboard.json
+        url: https://karpenter.sh/v1.14/getting-started/getting-started-with-karpenter/karpenter-performance-dashboard.json
 %{ endif ~}

--- a/infra/base/terraform/helm-values/nvidia-gpu-operator.yaml
+++ b/infra/base/terraform/helm-values/nvidia-gpu-operator.yaml
@@ -76,6 +76,8 @@ devicePlugin:
   env:
     - name: MOFED_ENABLED
       value: "false"
+    - name: GDRCOPY_ENABLED
+      value: "true"
 
 # DCGM service (nv-hostengine)
 dcgm:

--- a/infra/base/terraform/karpenter-resources/auto-mode/default.yaml
+++ b/infra/base/terraform/karpenter-resources/auto-mode/default.yaml
@@ -24,6 +24,8 @@ spec:
         - key: karpenter.sh/capacity-type
           operator: In
           values:
+            - reserved
+            - spot
             - on-demand
         - key: eks.amazonaws.com/instance-category
           operator: In
@@ -69,6 +71,7 @@ spec:
         - key: karpenter.sh/capacity-type
           operator: In
           values:
+            - reserved
             - on-demand
         - key: eks.amazonaws.com/instance-category
           operator: In
@@ -99,17 +102,4 @@ kind: NodeClass
 metadata:
   name: general
 spec:
-  ephemeralStorage:
-    iops: 3000
-    size: 80Gi
-    throughput: 125
-  networkPolicy: DefaultAllow
-  networkPolicyEventLogs: Disabled
-  role: ${node_iam_role}
-  securityGroupSelectorTerms:
-    - id: ${cluster_security_group_id}
-  snatPolicy: Random
-  subnetSelectorTerms:
-    - tags:
-        karpenter.sh/discovery: "${cluster_name}"
-        Name: "${cluster_name}-private-secondary*" # Only secondary cidr subnets
+  ${indent(2, ec2nodeclass)}

--- a/infra/base/terraform/karpenter-resources/auto-mode/neuron.yaml
+++ b/infra/base/terraform/karpenter-resources/auto-mode/neuron.yaml
@@ -30,6 +30,7 @@ spec:
         - key: karpenter.sh/capacity-type
           operator: In
           values:
+            - reserved
             - spot
             - on-demand
       taints:
@@ -42,17 +43,4 @@ kind: NodeClass
 metadata:
   name: neuron
 spec:
-  ephemeralStorage:
-    iops: 3000
-    size: 80Gi
-    throughput: 125
-  networkPolicy: DefaultAllow
-  networkPolicyEventLogs: Disabled
-  role: ${node_iam_role}
-  securityGroupSelectorTerms:
-    - id: ${cluster_security_group_id}
-  snatPolicy: Random
-  subnetSelectorTerms:
-    - tags:
-        karpenter.sh/discovery: "${cluster_name}"
-        Name: "${cluster_name}-private-secondary*" # Only secondary cidr subnets
+  ${indent(2, ec2nodeclass)}

--- a/infra/base/terraform/karpenter-resources/karpenter/default.yaml
+++ b/infra/base/terraform/karpenter-resources/karpenter/default.yaml
@@ -41,10 +41,10 @@ spec:
         - key: karpenter.sh/capacity-type
           operator: In
           values:
+            - reserved
             - spot
             - on-demand
       terminationGracePeriod: 24h
-
 ---
 apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass

--- a/infra/base/terraform/karpenter-resources/karpenter/gpu-p-static.yaml
+++ b/infra/base/terraform/karpenter-resources/karpenter/gpu-p-static.yaml
@@ -1,9 +1,11 @@
+%{ for instance_type, network_interfaces_yaml in jsondecode(efa_network_interfaces) ~}
+---
 apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
-  name: gpu
+  name: gpu-${replace(instance_type, ".", "-")}-static
 spec:
-  weight: 10
+  replicas: 0
   disruption:
     budgets:
       - nodes: 10%
@@ -15,20 +17,15 @@ spec:
         ai.eks.amazonaws.com/amiFamily: ${ami_family}
         accelerator: nvidia
     spec:
-      expireAfter: 336h
+      expireAfter: 720h
       nodeClassRef:
-        group: eks.amazonaws.com
-        kind: NodeClass
-        name: gpu
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: gpu-${replace(instance_type, ".", "-")}-static
       requirements:
-        - key: eks.amazonaws.com/instance-category
+        - key: node.kubernetes.io/instance-type
           operator: In
-          values:
-            - g
-        - key: eks.amazonaws.com/instance-generation
-          operator: Gt
-          values:
-            - "4"
+          values: ["${instance_type}"]
         - key: karpenter.sh/capacity-type
           operator: In
           values:
@@ -40,9 +37,11 @@ spec:
           key: nvidia.com/gpu
       terminationGracePeriod: 24h
 ---
-apiVersion: eks.amazonaws.com/v1
-kind: NodeClass
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
 metadata:
-  name: gpu
+  name: gpu-${replace(instance_type, ".", "-")}-static
 spec:
   ${indent(2, ec2nodeclass)}
+  ${indent(2, network_interfaces_yaml)}
+%{ endfor ~}

--- a/infra/base/terraform/karpenter-resources/karpenter/gpu-p.yaml
+++ b/infra/base/terraform/karpenter-resources/karpenter/gpu-p.yaml
@@ -29,6 +29,7 @@ spec:
         - key: karpenter.sh/capacity-type
           operator: In
           values:
+            - reserved
             - spot
             - on-demand
       taints:

--- a/infra/base/terraform/karpenter-resources/karpenter/gpu.yaml
+++ b/infra/base/terraform/karpenter-resources/karpenter/gpu.yaml
@@ -32,6 +32,7 @@ spec:
         - key: karpenter.sh/capacity-type
           operator: In
           values:
+            - reserved
             - spot
             - on-demand
       taints:

--- a/infra/base/terraform/karpenter-resources/karpenter/neuron.yaml
+++ b/infra/base/terraform/karpenter-resources/karpenter/neuron.yaml
@@ -30,6 +30,7 @@ spec:
         - key: karpenter.sh/capacity-type
           operator: In
           values:
+            - reserved
             - spot
             - on-demand
       taints:

--- a/infra/base/terraform/karpenter-resources/templates/al2023_ec2nodeclass.tpl
+++ b/infra/base/terraform/karpenter-resources/templates/al2023_ec2nodeclass.tpl
@@ -8,6 +8,11 @@ subnetSelectorTerms:
 securityGroupSelectorTerms:
   - tags:
       karpenter.sh/discovery: "${cluster_name}"
+capacityReservationSelectorTerms:
+  - tags:
+%{ for tag_key, tag_value in jsondecode(capacity_reservation_tags) ~}
+      ${tag_key}: "${tag_value}"
+%{ endfor ~}
 instanceStorePolicy: RAID0
 blockDeviceMappings:
   - deviceName: /dev/xvda

--- a/infra/base/terraform/karpenter-resources/templates/automode_nodeclass.tpl
+++ b/infra/base/terraform/karpenter-resources/templates/automode_nodeclass.tpl
@@ -1,0 +1,19 @@
+ephemeralStorage:
+  iops: 3000
+  size: 80Gi
+  throughput: 125
+networkPolicy: DefaultAllow
+networkPolicyEventLogs: Disabled
+role: ${node_iam_role}
+securityGroupSelectorTerms:
+  - id: ${cluster_security_group_id}
+snatPolicy: Random
+subnetSelectorTerms:
+  - tags:
+      karpenter.sh/discovery: "${cluster_name}"
+      Name: "${cluster_name}-private-secondary*" # Only secondary cidr subnets
+capacityReservationSelectorTerms:
+  - tags:
+%{ for tag_key, tag_value in jsondecode(capacity_reservation_tags) ~}
+      ${tag_key}: "${tag_value}"
+%{ endfor ~}

--- a/infra/base/terraform/karpenter-resources/templates/bottlerocket_ec2nodeclass.tpl
+++ b/infra/base/terraform/karpenter-resources/templates/bottlerocket_ec2nodeclass.tpl
@@ -8,6 +8,11 @@ subnetSelectorTerms:
 securityGroupSelectorTerms:
   - tags:
       karpenter.sh/discovery: "${cluster_name}"
+capacityReservationSelectorTerms:
+  - tags:
+%{ for tag_key, tag_value in jsondecode(capacity_reservation_tags) ~}
+      ${tag_key}: "${tag_value}"
+%{ endfor ~}
 %{ if !enable_soci_snapshotter || soci_snapshotter_use_instance_store ~}
 instanceStorePolicy: RAID0
 %{ endif ~}

--- a/infra/base/terraform/karpenter.tf
+++ b/infra/base/terraform/karpenter.tf
@@ -56,8 +56,10 @@ resource "helm_release" "karpenter" {
       clusterEndpoint: ${module.eks.cluster_endpoint}
       interruptionQueue: ${module.karpenter[0].queue_name}
       featureGates:
-        staticCapacity: true
+        nodeOverlay: true
         spotToSpotConsolidation: true
+        staticCapacity: true
+        capacityBuffer: true
     tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/infra/base/terraform/main.tf
+++ b/infra/base/terraform/main.tf
@@ -30,6 +30,7 @@ provider "kubectl" {
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
   token                  = ephemeral.aws_eks_cluster_auth.this.token
   load_config_file       = false
+  lazy_load              = true
 }
 
 ephemeral "aws_eks_cluster_auth" "this" {

--- a/infra/base/terraform/nodepools.tf
+++ b/infra/base/terraform/nodepools.tf
@@ -8,14 +8,18 @@ locals {
   nodepools     = merge(local.default_nodepools, var.nodepools)
   node_iam_role = var.enable_eks_auto_mode ? module.eks.node_iam_role_name : module.karpenter[0].node_iam_role_name
 
-  ec2nodeclass = templatefile("${path.module}/karpenter-resources/templates/${var.ami_family}_ec2nodeclass.tpl",
+  nodeclass_template = var.enable_eks_auto_mode ? "automode_nodeclass.tpl" : "${var.ami_family}_ec2nodeclass.tpl"
+
+  ec2nodeclass = templatefile("${path.module}/karpenter-resources/templates/${local.nodeclass_template}",
     {
       node_iam_role                       = local.node_iam_role
       cluster_name                        = module.eks.cluster_name
+      cluster_security_group_id           = module.eks.cluster_primary_security_group_id
       enable_soci_snapshotter             = var.enable_soci_snapshotter
       soci_snapshotter_use_instance_store = var.soci_snapshotter_use_instance_store
       data_disk_snapshot_id               = var.bottlerocket_data_disk_snapshot_id
       max_user_namespaces                 = var.max_user_namespaces
+      capacity_reservation_tags           = jsonencode(var.capacity_reservation_tags)
     }
   )
 }
@@ -31,6 +35,7 @@ data "kubectl_path_documents" "nodepools_manifests" {
     cluster_security_group_id = module.eks.cluster_primary_security_group_id
     ami_family                = var.ami_family
     ec2nodeclass              = local.ec2nodeclass
+    capacity_reservation_tags = jsonencode(var.capacity_reservation_tags)
     efa_network_interfaces    = jsonencode({ for k, v in module.efa_network_interfaces : k => v.karpenter_network_interfaces_yaml })
   }
   depends_on = [
@@ -48,6 +53,7 @@ data "kubectl_path_documents" "nodepools_manifests_dummy" {
     cluster_security_group_id = ""
     ami_family                = ""
     ec2nodeclass              = ""
+    capacity_reservation_tags = jsonencode(var.capacity_reservation_tags)
     efa_network_interfaces    = jsonencode({ for inst in local.efa_instance_types : inst => "" })
   }
 }

--- a/infra/base/terraform/s3.tf
+++ b/infra/base/terraform/s3.tf
@@ -32,6 +32,7 @@ resource "aws_s3_bucket" "models_bucket" {
 
   bucket        = var.s3_models_bucket_name != "" ? var.s3_models_bucket_name : null
   bucket_prefix = var.s3_models_bucket_name == "" ? "${local.name}-models-${local.region}-" : null
+  force_destroy = true
 
   tags = merge(local.tags, {
     Purpose = "ML Model Storage"

--- a/infra/base/terraform/variables.tf
+++ b/infra/base/terraform/variables.tf
@@ -137,7 +137,7 @@ DESC
 
 variable "vpc_cni_configuration" {
   description = "Configuration values for the VPC CNI addon (e.g., ENABLE_PREFIX_DELEGATION, WARM_PREFIX_TARGET). Passed as-is to the addon's configuration_values via jsonencode."
-  type        = map(any)
+  type        = any
   default     = {}
 }
 
@@ -380,6 +380,12 @@ variable "enable_leader_worker_set" {
   description = "Flag to enable the LeaderWorkerSet"
   type        = bool
   default     = false
+}
+
+variable "leader_worker_set_version" {
+  description = "LeaderWorkerSet version"
+  type        = string
+  default     = "v0.9.0"
 }
 
 # kubernetes-sigs/agent-sandbox controller
@@ -708,7 +714,7 @@ variable "ami_family" {
 variable "karpenter_version" {
   description = "Karpenter version"
   type        = string
-  default     = "1.13.0"
+  default     = "1.14.0"
 }
 
 # S3 Model Storage Variables
@@ -821,6 +827,14 @@ variable "aws_dranet_version" {
   description = "AWS DRANET driver version"
   type        = string
   default     = "1.0.0"
+}
+
+variable "capacity_reservation_tags" {
+  description = "Tags used by Karpenter EC2NodeClass capacityReservationSelectorTerms to discover EC2 Capacity Reservations (e.g. ODCRs / Capacity Blocks)"
+  type        = map(string)
+  default = {
+    "ai-on-eks" = "true"
+  }
 }
 
 variable "nodepools" {

--- a/infra/solutions/inference-ready-cluster/cleanup.sh
+++ b/infra/solutions/inference-ready-cluster/cleanup.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 # Copy the base into the folder
 mkdir -p ./terraform/_LOCAL
 cp -r ../../base/terraform/* ./terraform/_LOCAL
@@ -6,7 +9,6 @@ cp -r ../../base/terraform/* ./terraform/_LOCAL
 cd terraform/_LOCAL
 source ./common.sh
 
-bootstrap
 terraform_cleanup
 terraform_init
-terraform_apply
+terraform_destroy

--- a/infra/solutions/inference-ready-cluster/recipes/kimi-k3/README.md
+++ b/infra/solutions/inference-ready-cluster/recipes/kimi-k3/README.md
@@ -12,13 +12,7 @@ Deploy [Moonshot AI's Kimi K3](https://huggingface.co/moonshotai/Kimi-K3) on Ama
 ## Capacity Requirements
 
 This recipe of Kimi K3 requires **1 x p6-b300 instance** (8 x B300 GPUs) for inference.
-We recommend using [EC2 Capacity Blocks](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html) to guarantee availability for your deployment window. When purchasing a Capacity Block, tag the reservation with `ai-on-eks=true` — Karpenter's GPU NodePool is configured to discover and launch instances into Capacity Blocks matching this tag, ensuring your reserved capacity is automatically utilized when pods are scheduled.
-
-
-The deployment workflow:
-1. **Download** — Model weights are downloaded from Hugging Face to an S3 bucket via a high-throughput copy job (NVMe-backed for speed)
-2. **Stream** — vLLM loads model weights directly from S3 using the RunAI Model Streamer, enabling distributed loading without full local storage
-3. **Serve** — vLLM serves the model on GPU nodes provisioned by Karpenter
+We recommend using [EC2 Capacity Blocks](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html) to guarantee availability for your deployment window. When purchasing a Capacity Block, **tag the reservation with `ai-on-eks=true`** — Karpenter's GPU NodePool is configured to discover and launch instances into Capacity Blocks matching this tag, ensuring your reserved capacity is automatically utilized when pods are scheduled.
 
 ---
 

--- a/infra/solutions/inference-ready-cluster/recipes/kimi-k3/README.md
+++ b/infra/solutions/inference-ready-cluster/recipes/kimi-k3/README.md
@@ -1,0 +1,187 @@
+# Deploying Kimi K3 on Amazon EKS
+
+Deploy [Moonshot AI's Kimi K3](https://huggingface.co/moonshotai/Kimi-K3) on Amazon EKS using vLLM.
+
+## Prerequisites
+
+- An [Inference-Ready EKS Cluster](../../) deployed and running
+- `kubectl` configured to access the cluster
+- A [Hugging Face token](https://huggingface.co/settings/tokens) with access to the model
+- `helm` CLI installed (v3+)
+
+## Capacity Requirements
+
+This recipe of Kimi K3 requires **1 x p6-b300 instance** (8 x B300 GPUs) for inference.
+We recommend using [EC2 Capacity Blocks](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html) to guarantee availability for your deployment window. When purchasing a Capacity Block, tag the reservation with `ai-on-eks=true` — Karpenter's GPU NodePool is configured to discover and launch instances into Capacity Blocks matching this tag, ensuring your reserved capacity is automatically utilized when pods are scheduled.
+
+
+The deployment workflow:
+1. **Download** — Model weights are downloaded from Hugging Face to an S3 bucket via a high-throughput copy job (NVMe-backed for speed)
+2. **Stream** — vLLM loads model weights directly from S3 using the RunAI Model Streamer, enabling distributed loading without full local storage
+3. **Serve** — vLLM serves the model on GPU nodes provisioned by Karpenter
+
+---
+
+## Step 1: Clone the Repository
+
+```bash
+git clone https://github.com/awslabs/ai-on-eks.git
+cd ai-on-eks/infra/solutions/inference-ready-cluster
+```
+
+## Step 2: Deploy the Infrastructure
+
+Review and adjust `terraform/blueprint.tfvars` for your environment, then deploy:
+
+```bash
+./install.sh
+```
+
+Once complete, configure `kubectl`:
+
+```bash
+eval $(terraform -chdir="./terraform/_LOCAL" output -raw configure_kubectl)
+```
+
+Wait for all ArgoCD applications to become healthy:
+
+```bash
+kubectl wait --for=jsonpath='{.status.health.status}'=Healthy \
+  applications.argoproj.io --all \
+  -n argocd \
+  --timeout=600s
+```
+
+## Step 3: Prepare the Environment
+
+Export the Terraform outputs needed for subsequent steps:
+
+```bash
+eval "$(
+  terraform -chdir="./terraform/_LOCAL" output -json | jq -r '
+    "export S3_BUCKET=" + (.s3_models_buckets_name.value[0]),
+    "export MODEL_SYNC_SA=" + (.s3_models_sync_sa.value),
+    "export INFERENCE_SA=" + (.s3_models_inference_sa.value)
+  '
+)"
+```
+
+Create service accounts with for S3 access:
+
+```bash
+kubectl -n default create sa $MODEL_SYNC_SA
+kubectl -n default create sa $INFERENCE_SA
+```
+
+## Step 4: Create the Hugging Face Secret
+
+```bash
+kubectl -n default create secret generic hf-token \
+  --from-literal=token=<YOUR_HF_TOKEN>
+```
+
+> Replace `<YOUR_HF_TOKEN>` with your actual [Hugging Face token](https://huggingface.co/settings/tokens).
+
+## Step 5: Download Model Weights to S3
+
+Add the AI on EKS Helm chart repository:
+
+```bash
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+```
+
+Launch the S3 copy job. This downloads Kimi K3 weights from Hugging Face to your S3 bucket using NVMe-backed storage for throughput:
+
+```bash
+export REPO_ID="moonshotai/Kimi-K3"
+
+helm install s3-copy-moonshot-kimi-k3 ai-on-eks/inference-charts \
+  -n default -f - <<EOF
+s3ModelCopy:
+  namespace: default
+  model: $REPO_ID
+  s3Bucket: $S3_BUCKET
+  serviceAccountName: $MODEL_SYNC_SA
+  requireLocalNvme: true
+  storageSize: 600
+  requireNetworkBandwidth: 25000
+  parameters:
+    fileWorkers: 35
+EOF
+```
+
+> This job runs on an NVMe-equipped instance and uses 35 parallel workers to maximize download speed. Storage is set to 600 GiB to accommodate the full model weights.
+
+Monitor progress:
+
+```bash
+kubectl logs -n default -f -l app.kubernetes.io/name=s3-model-copy,app.kubernetes.io/instance=s3-copy-moonshot-kimi-k3
+```
+
+Once the job completes successfully, clean up the copy resources:
+
+```bash
+helm uninstall s3-copy-moonshot-kimi-k3 -n default
+```
+
+## Step 6: Deploy vLLM for Inference
+
+Deploy vLLM with the RunAI Model Streamer to load weights directly from S3 in a distributed fashion:
+
+```bash
+helm upgrade --install kimi-k3-vllm ai-on-eks/inference-charts -n default \
+  -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-kimi-k3-vllm-b300.yaml \
+  --set modelPath="s3://${S3_BUCKET}/${REPO_ID}" \
+  --set serviceAccountName="${INFERENCE_SA}" \
+  --set modelParameters.loadFormat="runai_streamer" \
+  --set modelParameters.modelLoaderExtraConfig="'{\"distributed\":true}'"
+```
+
+Verify the deployment is running:
+
+```bash
+kubectl -n default get pods -l ai.eks.amazonaws.com/name=kimi-k3-vllm --watch
+```
+
+> The deployment can take up to 15 minutes to become ready. This includes node provisioning, streaming model weights from S3, graph compilation, and CUDA kernel warm-up.
+
+Monitor progress by tailing the logs:
+
+```bash
+kubectl -n default logs -f -l ai.eks.amazonaws.com/name=kimi-k3-vllm
+```
+
+## Validation
+
+Once the pods are ready, test the endpoint:
+
+```bash
+kubectl -n default port-forward svc/kimi-k3-vllm 8000:8000
+```
+
+In a separate terminal:
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "moonshotai/Kimi-K3",
+    "messages": [{"role": "user", "content": "What is Mixture of Experts?"}],
+    "max_tokens": 256
+  }'
+```
+
+## Cleanup
+
+Remove the inference deployment:
+
+```bash
+helm uninstall kimi-k3-vllm -n default
+```
+
+To remove all infrastructure:
+
+```bash
+./cleanup.sh
+```

--- a/infra/solutions/inference-ready-cluster/terraform/blueprint.tfvars
+++ b/infra/solutions/inference-ready-cluster/terraform/blueprint.tfvars
@@ -1,14 +1,14 @@
 name                             = "inference-cluster"
+enable_aws_efa_k8s_device_plugin = true
 enable_kuberay_operator          = true
 enable_ai_ml_observability_stack = true
 enable_aibrix_stack              = true
 enable_leader_worker_set         = true
+enable_s3_models_storage         = true
 solution_description             = "Guidance for Automated Deployment of Inference ready Amazon EKS Clusters"
 solution_id                      = "SO9615"
-availability_zones_count         = 4
-enable_soci_snapshotter          = true
-# region                           = "us-west-2"
-# eks_cluster_version              = "1.34"
+region                           = "us-west-2"
+eks_cluster_version              = "1.35"
 
 # -------------------------------------------------------------------------------------
 # EKS Addons Configuration
@@ -27,8 +27,7 @@ enable_cluster_addons = {
   kube-proxy                      = true
   vpc-cni                         = true
   eks-pod-identity-agent          = true
-  aws-ebs-csi-driver              = false
-  metrics-server                  = false
-  eks-node-monitoring-agent       = false
+  metrics-server                  = true
+  eks-node-monitoring-agent       = true
   amazon-cloudwatch-observability = false
 }


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/ai-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

Karpenter reserved-capacity (ODCR / Capacity Blocks) support
- New capacity_reservation_tags variable (default ai-on-eks=true) rendered into capacityReservationSelectorTerms in the AL2023, Bottlerocket, and new Auto Mode nodeclass templates
- reserved added to karpenter.sh/capacity-type on all NodePools (default, gpu, gpu-p, neuron, plus Auto Mode equivalents)
- New gpu-p-static.yaml NodePool/EC2NodeClass pair — per-EFA-instance-type static-capacity pools (replicas: 0) with EFA network interfaces
- Karpenter feature gates: added nodeOverlay and capacityBuffer; bumped Karpenter 1.13.0 → 1.14.0 (and Grafana dashboard URLs v1.11 → v1.14)

Auto Mode nodeclass refactor
- Extracted the inlined Auto Mode NodeClass spec from auto-mode/{default,gpu,neuron}.yaml into a shared automode_nodeclass.tpl, selected via local.nodeclass_template in nodepools.tf — removes triplicated config and lets Auto Mode pick up capacity reservations too

Version parameterization
- leader-worker-set.yaml now a templatefile driven by a new leader_worker_set_version variable (default v0.9.0, was hardcoded v0.7.0)

Solution / Inference Ready Cluster (blueprint.tfvars)
- Enabled EFA device plugin, S3 model storage, metrics-server, node-monitoring-agent; EKS 1.35
- install.sh switched from sourcing base install.sh to common.sh + explicit bootstrap / terraform_cleanup / terraform_init / terraform_apply, now using S3 tfstate bucket

New recipe
- recipes/kimi-k3/README.md — Kimi K3 on p6-b300 via vLLM, with S3 download → RunAI Model Streamer → serve workflow and Capacity Block guidance

Misc
- GPU operator: GDRCOPY_ENABLED=true
- kubectl provider lazy_load = true; models S3 bucket force_destroy = true; vpc_cni_configuration type relaxed map(any) → any

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
