### PR TITLE
feat: aoe-capacity cross-region GPU capacity scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ![AI on EKS](website/static/img/aioeks-logo-green.png)
+
 # [AI on Amazon EKS (AIoEKS)](https://awslabs.github.io/ai-on-eks/)
-*(Pronounced: "AI on EKS")*
+
+_(Pronounced: "AI on EKS")_
+
 > 💡 **Optimized Solutions for AI and ML on EKS**
 
 > ⚠️ **This repository is under active development as we support the new infrastructure format. Please raise any issues you may encounter**
@@ -16,6 +19,7 @@ Take advantage of high-performance [NVIDIA GPUs](https://aws.amazon.com/nvidia/)
 > **Note:** AIoEKS is in active development. For upcoming features and enhancements, check out the [issues](https://github.com/awslabs/ai-on-eks/issues) section.
 
 ## 🏃‍♀️Getting Started
+
 In this repository, you'll find a variety of deployment blueprints for creating AI/ML platforms with Amazon EKS clusters. These examples are just a small selection of the available blueprints - visit the [AIoEKS website](https://awslabs.github.io/ai-on-eks/) for the complete list of options.
 
 ### 🧠 AI
@@ -37,23 +41,37 @@ In this repository, you'll find a variety of deployment blueprints for creating 
 🚀 [Rate Limiting](blueprints/gateways/envoy-ai-gateway/rate-limiting/) 👈 Usage-based rate limiting with automatic tracking
 
 ## 📚 Documentation
+
 For instructions on how to deploy AI on EKS patterns and run sample tests, visit the [AIoEKS website](https://awslabs.github.io/ai-on-eks/).
 
 ## 🏆 Motivation
+
 [Kubernetes](https://kubernetes.io/) is a widely adopted system for orchestrating containerized software at scale. As more users migrate their AI and machine learning workloads to Kubernetes, they often face the complexity of managing the Kubernetes ecosystem and selecting the right tools and configurations for their specific needs.
 
 At [AWS](https://aws.amazon.com/), we understand the challenges users encounter when deploying and scaling AI/ML workloads on Kubernetes. To simplify the process and enable users to quickly conduct proof-of-concepts and build clusters, we have developed AI on EKS (AIoEKS). AIoEKS offers opinionated open-source blueprints that provide end-to-end logging and observability, making it easier for users to deploy and manage Ray, vLLM, Kubeflow, MLFlow, Jupyter and other AI/ML workloads. With AIoEKS, users can confidently leverage the power of Kubernetes for their AI and machine learning needs without getting overwhelmed by its complexity.
 
 ## 🤝 Support & Feedback
+
 AIoEKS is maintained by AWS Solution Architects and is not an AWS service. Support is provided on a best effort basis by the AI on EKS community. If you have feedback, feature ideas, or wish to report bugs, please use the [Issues](https://github.com/awslabs/ai-on-eks/issues) section of this GitHub.
 
 ## 🔐 Security
+
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
 
 ## 💼 License
+
 This library is licensed under the Apache 2.0 License.
 
 ## 🙌 Community
+
 We welcome all individuals who are enthusiastic about AI on Kubernetes to become a part of this open source community. Your contributions and participation are invaluable to the success of this project.
 
 Built with ❤️ at AWS.
+
+## GPU Capacity Scanner
+
+[`tools/capacity/`](tools/capacity/) provides `aoe-capacity`, a cross-region GPU
+capacity scanner built on public AWS APIs (spot placement scores, spot price history,
+instance-type offerings, on-demand pricing). Run
+`aoe-capacity find g6e.12xlarge --regions all` to get a ranked
+(region, instance, price) list. See [`tools/capacity/README.md`](tools/capacity/README.md).

--- a/tools/capacity/README.md
+++ b/tools/capacity/README.md
@@ -1,0 +1,23 @@
+# GPU Capacity Scanner (`aoe-capacity`)
+
+Answers "where in the world can I get these GPUs right now, and for how much?"
+using only public AWS APIs: `get_spot_placement_scores`,
+`describe_spot_price_history`, `describe_instance_type_offerings`, and pricing
+`get_products`.
+
+## Install
+
+    pip install -e .
+
+## Use
+
+    aoe-capacity find g6e.12xlarge --regions all
+    aoe-capacity find p5.48xlarge --regions us-east-2,us-west-2 --json
+
+Output is ranked by effective price ascending (spot when available, else on-demand).
+`--regions all` (the default) scans every enabled region in the account.
+
+## Library
+
+    from tools.capacity.scan import scan
+    scan(["g6e.12xlarge"], regions=None)   # -> list[CapacityOption] sorted by price

--- a/tools/capacity/__init__.py
+++ b/tools/capacity/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tools/capacity/cli.py
+++ b/tools/capacity/cli.py
@@ -1,0 +1,52 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""CLI: aoe-capacity find <instance_type> [--regions all|r1,r2] [--json]."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from tools.capacity.scan import scan
+
+
+def _parse_regions(value: str | None) -> list[str] | None:
+    if value is None or value == "all":
+        return None
+    return [r.strip() for r in value.split(",") if r.strip()]
+
+
+def _print_table(rows: list[dict]) -> None:
+    if not rows:
+        print("No capacity found.")
+        return
+    header = f"{'REGION':<16}{'INSTANCE':<18}{'SPOT $/hr':>10}{'OD $/hr':>10}{'SCORE':>7}  AVAIL"
+    print(header)
+    for r in rows:
+        spot = "-" if r["spot_price_usd_hr"] is None else f"{r['spot_price_usd_hr']:.2f}"
+        od = "-" if r["on_demand_price_usd_hr"] is None else f"{r['on_demand_price_usd_hr']:.2f}"
+        score = "-" if r["spot_placement_score"] is None else str(r["spot_placement_score"])
+        print(f"{r['region']:<16}{r['instance_type']:<18}{spot:>10}{od:>10}{score:>7}  {r['availability']}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="aoe-capacity")
+    sub = parser.add_subparsers(dest="command", required=True)
+    find = sub.add_parser("find", help="find capacity for an instance type")
+    find.add_argument("instance_type")
+    find.add_argument("--regions", default="all", help="all | comma,separated,regions")
+    find.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+
+    args = parser.parse_args(argv)
+    if args.command == "find":
+        rows = scan([args.instance_type], regions=_parse_regions(args.regions))
+        if args.json:
+            print(json.dumps(rows, indent=2))
+        else:
+            _print_table(rows)
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/capacity/pyproject.toml
+++ b/tools/capacity/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "aoe-capacity"
+version = "0.1.0"
+description = "ai-on-eks cross-region GPU capacity scanner (public AWS APIs only)"
+requires-python = ">=3.11"
+dependencies = ["boto3>=1.34"]
+
+[project.optional-dependencies]
+test = ["pytest>=8.0", "botocore>=1.34"]
+
+[project.scripts]
+aoe-capacity = "tools.capacity.cli:main"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"

--- a/tools/capacity/scan.py
+++ b/tools/capacity/scan.py
@@ -1,0 +1,130 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Cross-region GPU capacity scanner using PUBLIC AWS APIs only.
+
+Public APIs: get_spot_placement_scores, describe_spot_price_history,
+describe_instance_type_offerings, pricing get_products.
+"""
+from __future__ import annotations
+
+import json
+
+import boto3
+
+PRICING_REGION = "us-east-1"
+
+
+def _default_factory(service: str, region: str):
+    return boto3.client(service, region_name=region)
+
+
+def _enabled_regions(client_factory) -> list[str]:
+    ec2 = client_factory("ec2", PRICING_REGION)
+    resp = ec2.describe_regions(AllRegions=False)
+    return sorted(r["RegionName"] for r in resp["Regions"])
+
+
+def _placement_scores(client_factory, instance_types, regions) -> dict[str, int]:
+    ec2 = client_factory("ec2", PRICING_REGION)
+    resp = ec2.get_spot_placement_scores(
+        InstanceTypes=instance_types,
+        TargetCapacity=1,
+        RegionNames=regions,
+        SingleAvailabilityZone=False,
+    )
+    return {s["Region"]: s["Score"] for s in resp.get("SpotPlacementScores", [])}
+
+
+def _is_offered(client_factory, region, instance_type) -> bool:
+    ec2 = client_factory("ec2", region)
+    resp = ec2.describe_instance_type_offerings(
+        LocationType="region",
+        Filters=[{"Name": "instance-type", "Values": [instance_type]}],
+    )
+    return bool(resp.get("InstanceTypeOfferings"))
+
+
+def _spot_price(client_factory, region, instance_type) -> float | None:
+    ec2 = client_factory("ec2", region)
+    resp = ec2.describe_spot_price_history(
+        InstanceTypes=[instance_type],
+        ProductDescriptions=["Linux/UNIX"],
+        MaxResults=1,
+    )
+    history = resp.get("SpotPriceHistory", [])
+    if not history:
+        return None
+    return float(history[0]["SpotPrice"])
+
+
+def _on_demand_price(client_factory, region, instance_type) -> float | None:
+    pricing = client_factory("pricing", PRICING_REGION)
+    resp = pricing.get_products(
+        ServiceCode="AmazonEC2",
+        Filters=[
+            {"Type": "TERM_MATCH", "Field": "instanceType", "Value": instance_type},
+            {"Type": "TERM_MATCH", "Field": "regionCode", "Value": region},
+            {"Type": "TERM_MATCH", "Field": "operatingSystem", "Value": "Linux"},
+            {"Type": "TERM_MATCH", "Field": "tenancy", "Value": "Shared"},
+            {"Type": "TERM_MATCH", "Field": "preInstalledSw", "Value": "NA"},
+            {"Type": "TERM_MATCH", "Field": "capacitystatus", "Value": "Used"},
+        ],
+        MaxResults=1,
+    )
+    price_list = resp.get("PriceList", [])
+    if not price_list:
+        return None
+    doc = json.loads(price_list[0])
+    for sku in doc.get("terms", {}).get("OnDemand", {}).values():
+        for term in sku.values():
+            for dim in term.get("priceDimensions", {}).values():
+                usd = dim.get("pricePerUnit", {}).get("USD")
+                if usd is not None:
+                    return round(float(usd), 4)
+    return None
+
+
+def _effective_price(option: dict) -> float:
+    if option["spot_price_usd_hr"] is not None:
+        return option["spot_price_usd_hr"]
+    if option["on_demand_price_usd_hr"] is not None:
+        return option["on_demand_price_usd_hr"]
+    return float("inf")
+
+
+def scan(
+    instance_types: list[str],
+    regions: list[str] | None = None,
+    client_factory=None,
+) -> list[dict]:
+    """regions=None -> all enabled regions. Returns list sorted by price asc."""
+    client_factory = client_factory or _default_factory
+    if regions is None:
+        regions = _enabled_regions(client_factory)
+
+    scores = _placement_scores(client_factory, instance_types, regions)
+
+    options: list[dict] = []
+    for region in regions:
+        for instance_type in instance_types:
+            if not _is_offered(client_factory, region, instance_type):
+                continue
+            spot = _spot_price(client_factory, region, instance_type)
+            on_demand = _on_demand_price(client_factory, region, instance_type)
+            if spot is not None:
+                availability = "spot"
+            elif on_demand is not None:
+                availability = "on-demand"
+            else:
+                availability = "none"
+            options.append({
+                "region": region,
+                "instance_type": instance_type,
+                "spot_price_usd_hr": spot,
+                "on_demand_price_usd_hr": on_demand,
+                "spot_placement_score": scores.get(region),
+                "availability": availability,
+            })
+
+    options.sort(key=_effective_price)
+    return options

--- a/tools/capacity/tests/__init__.py
+++ b/tools/capacity/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tools/capacity/tests/test_scan.py
+++ b/tools/capacity/tests/test_scan.py
@@ -1,0 +1,127 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import json
+
+import boto3
+from botocore.stub import Stubber
+
+from tools.capacity.scan import scan
+
+
+def _stubbed_factory():
+    """Return (factory, stubbers) with canned responses for one region scan."""
+    clients: dict[tuple[str, str], object] = {}
+    stubbers: dict[tuple[str, str], Stubber] = {}
+
+    def make(service, region):
+        key = (service, region)
+        if key in clients:
+            return clients[key]
+        client = boto3.client(service, region_name=region)
+        stub = Stubber(client)
+        clients[key] = client
+        stubbers[key] = stub
+        return client
+
+    return make, clients, stubbers
+
+
+def test_scan_single_region_ranks_and_maps_fields():
+    factory, clients, stubbers = _stubbed_factory()
+
+    # 1) placement scores queried from us-east-1 across the given regions
+    ec2_use1 = factory("ec2", "us-east-1")
+    stubbers[("ec2", "us-east-1")].add_response(
+        "get_spot_placement_scores",
+        {"SpotPlacementScores": [{"Region": "us-east-2", "Score": 7}]},
+        {
+            "InstanceTypes": ["g6e.12xlarge"],
+            "TargetCapacity": 1,
+            "RegionNames": ["us-east-2"],
+            "SingleAvailabilityZone": False,
+        },
+    )
+
+    # 2) offering check in us-east-2
+    ec2_use2 = factory("ec2", "us-east-2")
+    stubbers[("ec2", "us-east-2")].add_response(
+        "describe_instance_type_offerings",
+        {"InstanceTypeOfferings": [
+            {"InstanceType": "g6e.12xlarge", "LocationType": "region", "Location": "us-east-2"}
+        ]},
+        {"LocationType": "region",
+         "Filters": [{"Name": "instance-type", "Values": ["g6e.12xlarge"]}]},
+    )
+    # 3) spot price history in us-east-2
+    stubbers[("ec2", "us-east-2")].add_response(
+        "describe_spot_price_history",
+        {"SpotPriceHistory": [
+            {"InstanceType": "g6e.12xlarge", "SpotPrice": "4.21",
+             "ProductDescription": "Linux/UNIX", "AvailabilityZone": "us-east-2a"}
+        ]},
+        {"InstanceTypes": ["g6e.12xlarge"],
+         "ProductDescriptions": ["Linux/UNIX"],
+         "MaxResults": 1},
+    )
+
+    # 4) on-demand price from pricing (us-east-1)
+    price_doc = {
+        "terms": {"OnDemand": {"sku.jr": {"sku.jr.term": {
+            "priceDimensions": {"sku.jr.term.dim": {
+                "pricePerUnit": {"USD": "10.4900000000"}}}}}}}
+    }
+    factory("pricing", "us-east-1")
+    stubbers[("pricing", "us-east-1")].add_response(
+        "get_products",
+        {"PriceList": [json.dumps(price_doc)]},
+        {"ServiceCode": "AmazonEC2",
+         "Filters": [
+             {"Type": "TERM_MATCH", "Field": "instanceType", "Value": "g6e.12xlarge"},
+             {"Type": "TERM_MATCH", "Field": "regionCode", "Value": "us-east-2"},
+             {"Type": "TERM_MATCH", "Field": "operatingSystem", "Value": "Linux"},
+             {"Type": "TERM_MATCH", "Field": "tenancy", "Value": "Shared"},
+             {"Type": "TERM_MATCH", "Field": "preInstalledSw", "Value": "NA"},
+             {"Type": "TERM_MATCH", "Field": "capacitystatus", "Value": "Used"},
+         ],
+         "MaxResults": 1},
+    )
+
+    for stub in stubbers.values():
+        stub.activate()
+
+    result = scan(["g6e.12xlarge"], regions=["us-east-2"], client_factory=factory)
+
+    assert result == [{
+        "region": "us-east-2",
+        "instance_type": "g6e.12xlarge",
+        "spot_price_usd_hr": 4.21,
+        "on_demand_price_usd_hr": 10.49,
+        "spot_placement_score": 7,
+        "availability": "spot",
+    }]
+
+
+def test_scan_marks_none_when_not_offered():
+    factory, clients, stubbers = _stubbed_factory()
+    stubbers[("ec2", "us-east-1")] = None  # placeholder; created below
+
+    ec2_use1 = factory("ec2", "us-east-1")
+    stubbers[("ec2", "us-east-1")].add_response(
+        "get_spot_placement_scores",
+        {"SpotPlacementScores": []},
+        {"InstanceTypes": ["p5.48xlarge"], "TargetCapacity": 1,
+         "RegionNames": ["eu-west-1"], "SingleAvailabilityZone": False},
+    )
+    ec2_euw1 = factory("ec2", "eu-west-1")
+    stubbers[("ec2", "eu-west-1")].add_response(
+        "describe_instance_type_offerings",
+        {"InstanceTypeOfferings": []},
+        {"LocationType": "region",
+         "Filters": [{"Name": "instance-type", "Values": ["p5.48xlarge"]}]},
+    )
+    for stub in stubbers.values():
+        if stub is not None:
+            stub.activate()
+
+    result = scan(["p5.48xlarge"], regions=["eu-west-1"], client_factory=factory)
+    assert result == []

--- a/website/docs/guidance/capacity-scanner.md
+++ b/website/docs/guidance/capacity-scanner.md
@@ -1,0 +1,26 @@
+---
+title: GPU Capacity Scanner
+sidebar_label: Capacity Scanner
+---
+
+# GPU Capacity Scanner
+
+GPU capacity is scarce and priced differently in every region. The `aoe-capacity`
+tool scans all enabled regions and returns a ranked list of where a given instance
+type is available and what it costs, using only public AWS APIs.
+
+## Usage
+
+    aoe-capacity find g6e.12xlarge --regions all
+    aoe-capacity find p5.48xlarge --regions us-east-2,us-west-2 --json
+
+Each row reports the region, spot price, on-demand price, the spot placement score
+(1-10, higher is better), and availability (`spot`, `on-demand`, or `none`). Results
+are sorted by effective price ascending so the cheapest viable option is first.
+
+## APIs used
+
+`get_spot_placement_scores`, `describe_spot_price_history`,
+`describe_instance_type_offerings`, and pricing `get_products`. No internal or
+account-privileged APIs are used, so the tool runs anywhere with standard EC2 and
+Pricing read permissions.


### PR DESCRIPTION
## What

Adds `tools/capacity/` — `aoe-capacity find <instance_type> [--regions all|r1,r2] [--json]`, a cross-region GPU capacity scanner. `scan()` returns a list of (region, instance, spot price, on-demand price, spot placement score, availability), sorted by effective price ascending.

## Why

GPU capacity is scarce and priced differently per region. Customers get "where in the world can I get these GPUs right now, and for how much?" as a first-class tool.

## Scope / safety

**Public AWS APIs only:** `get_spot_placement_scores`, `describe_spot_price_history`, `describe_instance_type_offerings`, pricing `get_products`. No internal APIs. Additive directory; updates root README and adds `website/docs/guidance/capacity-scanner.md`. Apache 2.0 headers throughout.

## Testing

`pip install -e tools/capacity[test] && python -m pytest tools/capacity/tests -v` — `botocore` Stubber-based unit tests covering field mapping, ranking, and the "not offered -> excluded" path. No live AWS calls in CI.
