### PR TITLE
feat: deploy/find-capacity/benchmark/troubleshoot agent skills

### DIFF
--- a/.claude/skills/benchmark-model/SKILL.md
+++ b/.claude/skills/benchmark-model/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: benchmark-model
+description: Use when the user wants to benchmark a deployed inference endpoint (throughput, TTFT, ITL, cost). Runs a concurrency sweep against an OpenAI-compatible endpoint on the cluster.
+---
+
+# Benchmark a Deployed Model
+
+Measure tokens/sec, time-to-first-token (TTFT), inter-token latency (ITL), and cost per
+1M tokens for a running endpoint.
+
+## Steps
+
+1. **Locate the endpoint.** Confirm the deployment is up and port-forward it:
+
+   kubectl get deployment <name>
+   kubectl port-forward svc/<name> 8000:8000 &
+
+2. **Run a concurrency sweep.** Drive the endpoint at 2-3 concurrency points
+   (e.g. 1, 4, 8), capturing tokens/sec, TTFT, and ITL at each. Use the same
+   `inference-perf`-style harness the factory uses; point it at
+   `http://localhost:8000/v1` with the model id set to the entry's `hf_repo`.
+
+3. **Compute cost/1M tokens.** cost_per_1m_tok_usd = (instance $/hr) / (tokens_per_sec \*
+   3600 / 1e6). Use the price from `aoe-capacity find <instance_type>` for the region the
+   model runs in.
+
+4. **Report.** Produce a table: concurrency, tokens_per_sec, ttft_ms, itl_ms,
+   cost_per_1m_tok_usd. These are exactly the fields a `registry/models/<name>.yaml`
+   `instances[]` row records — hand them to whoever updates the registry entry.

--- a/.claude/skills/deploy-model/SKILL.md
+++ b/.claude/skills/deploy-model/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: deploy-model
+description: Use when the user wants to deploy an open-weight model on EKS (e.g. "deploy qwen3-coder-30b", "run Kimi K3 on the cluster"). Reads the registry, checks capacity, generates a blueprint, applies it, and verifies the endpoint.
+---
+
+# Deploy Model on EKS
+
+Deploy a registered open-weight model onto the EKS cluster and confirm it serves.
+
+## Steps
+
+1.  **Resolve the entry.** Look for `registry/models/<name>.yaml` matching the model the
+    user named. If it exists, read it. If it does NOT exist, tell the user the model is
+    unverified and offer the best-effort sizing walk-through (params -> VRAM -> instance
+    count); mark anything you produce as unverified. Do not invent benchmark numbers.
+
+2.  **Check capacity.** Read the first `instances[].type` from the entry (the verified
+    instance type). Run:
+
+        aoe-capacity find <instance_type> --regions all
+
+    Pick the top-ranked (region, price) row. Tell the user the region and expected $/hr.
+
+3.  **Ensure the HF token secret exists.** The blueprint reads the Hugging Face token
+    from the `hf-token` secret. Verify or create it:
+
+        kubectl get secret hf-token || \
+          kubectl create secret generic hf-token --from-literal=token=$HF_TOKEN
+
+4.  **Generate the blueprint.** Default target is `vllm`; use `dynamo` only if the user
+    asks for the Dynamo graph deployment:
+
+        aoe-blueprint gen registry/models/<name>.yaml --target vllm -o /tmp/<name>.yaml
+
+5.  **Apply it.**
+
+    kubectl apply -f /tmp/<name>.yaml
+
+6.  **Verify the endpoint.** Wait for the pod, then hit the OpenAI-compatible endpoint:
+
+        kubectl rollout status deployment/<name> --timeout=20m
+        kubectl port-forward svc/<name> 8000:8000 &
+        curl -s localhost:8000/v1/chat/completions \
+          -H 'Content-Type: application/json' \
+          -d '{"model":"<hf_repo>","messages":[{"role":"user","content":"hello"}]}'
+
+    A JSON completion means the deploy is live. Report the region, instance type, and a
+    one-line sample of the response. If the pod is stuck, hand off to the
+    troubleshoot-inference skill.

--- a/.claude/skills/find-capacity/SKILL.md
+++ b/.claude/skills/find-capacity/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: find-capacity
+description: Use when the user asks where GPU capacity is available or cheapest (e.g. "where can I get 8xH100 cheapest?", "is g6e.12xlarge available in us-west-2?"). Wraps the aoe-capacity scanner.
+---
+
+# Find GPU Capacity
+
+Answer "where in the world can I get these GPUs, and for how much?" using public AWS
+APIs only.
+
+## Steps
+
+1.  **Map the request to an instance type.** If the user names a GPU count/type
+    ("8xH100"), translate to the EC2 instance type (8xH100 -> `p5.48xlarge`;
+    1xH100 -> `p5.4xlarge`; L40S -> `g6e.*`). If they already gave an instance type, use
+    it directly.
+
+2.  **Scan.** For all regions:
+
+        aoe-capacity find <instance_type> --regions all
+
+    For specific regions:
+
+        aoe-capacity find <instance_type> --regions us-east-2,us-west-2
+
+3.  **Report the ranking.** Present the top rows (region, spot $/hr, on-demand $/hr, spot
+    placement score, availability), cheapest first. Call out the single best option and
+    whether it is spot or on-demand. Add `--json` if the user wants machine-readable
+    output.

--- a/.claude/skills/troubleshoot-inference/SKILL.md
+++ b/.claude/skills/troubleshoot-inference/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: troubleshoot-inference
+description: Use when a model deployment on EKS is failing or degraded (pod CrashLoopBackOff, OOM, CUDA errors, Karpenter not scaling, HF token / gated repo errors). Diagnoses and fixes common vLLM-on-EKS failures.
+---
+
+# Troubleshoot Inference on EKS
+
+Diagnose and fix the common failure modes seen deploying vLLM/Dynamo on EKS.
+
+## Steps
+
+1. **Get the symptom.** Read pod state and recent logs:
+
+   kubectl get pods -l app=<name>
+   kubectl describe pod <pod>
+   kubectl logs <pod> --tail=200
+
+2. **Match the failure:**
+   - **`Pending`, no node** -> Karpenter has not scaled. Check the NodePool matches the
+     blueprint's `node.kubernetes.io/instance-type`, and that the region has capacity
+     (`aoe-capacity find <instance_type>`). Capacity may be zero in this region; move to
+     a region the scanner ranks higher.
+   - **`OOMKilled` / CUDA OOM in logs** -> the model does not fit. Increase
+     `--tensor-parallel-size` (needs more GPUs / a bigger instance) or lower
+     `--max-model-len`. Regenerate with `aoe-blueprint gen`.
+   - **`CUDA error` / driver mismatch** -> the node's NVIDIA driver is older than the
+     container's CUDA. Confirm the GPU AMI / device-plugin versions match the image.
+   - **401 / gated repo pulling weights** -> the `hf-token` secret is missing or the
+     token lacks access. Recreate it:
+     `kubectl create secret generic hf-token --from-literal=token=$HF_TOKEN`.
+   - **`ValueError: architecture not recognized`** -> vLLM version predates the model
+     arch. Pin a newer `container_image` in the registry entry.
+
+3. **Verify the fix.** Re-apply, then re-run the deploy-model verification curl. Report
+   what the root cause was and what changed.

--- a/.kiro/skills/benchmark-model/SKILL.md
+++ b/.kiro/skills/benchmark-model/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: benchmark-model
+description: Benchmark a deployed inference endpoint (throughput, TTFT, ITL, cost). Use when the user wants to measure a running model endpoint. Runs a concurrency sweep against an OpenAI-compatible endpoint on the cluster.
+---
+
+# Benchmark a Deployed Model
+
+When the user wants to benchmark a running endpoint:
+
+1. Confirm the deployment is up; port-forward `svc/<name>` to localhost:8000.
+2. Run a 2-3 point concurrency sweep against `http://localhost:8000/v1`, capturing
+   tokens_per_sec, ttft_ms, itl_ms.
+3. cost_per_1m_tok_usd = (instance $/hr) / (tokens_per_sec \* 3600 / 1e6), using
+   `aoe-capacity` for the region's price.
+4. Report a table with exactly the fields a registry `instances[]` row records.

--- a/.kiro/skills/deploy-model/SKILL.md
+++ b/.kiro/skills/deploy-model/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: deploy-model
+description: Deploy a registered open-weight model on EKS. Use when the user asks to deploy a model (e.g. "deploy qwen3-coder-30b"). Resolves the registry entry, checks capacity, generates a blueprint, applies it, and verifies the endpoint.
+---
+
+# Deploy Model on EKS
+
+When the user asks to deploy an open-weight model on EKS:
+
+1. Resolve `registry/models/<name>.yaml`. If absent, do the best-effort sizing
+   walk-through (params -> VRAM -> instance count) and flag results unverified; never
+   invent benchmark numbers.
+2. Read the verified `instances[].type`, then `aoe-capacity find <instance_type> --regions all`
+   and pick the cheapest ranked region.
+3. Ensure the `hf-token` secret exists (`kubectl create secret generic hf-token --from-literal=token=$HF_TOKEN`).
+4. `aoe-blueprint gen registry/models/<name>.yaml --target vllm -o /tmp/<name>.yaml`.
+5. `kubectl apply -f /tmp/<name>.yaml`.
+6. `kubectl rollout status deployment/<name> --timeout=20m`, port-forward, and curl
+   `/v1/chat/completions`. A JSON completion confirms success; otherwise use the
+   troubleshoot-inference skill.

--- a/.kiro/skills/find-capacity/SKILL.md
+++ b/.kiro/skills/find-capacity/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: find-capacity
+description: Find where GPU capacity is available or cheapest across AWS regions. Use when the user asks "where can I get 8xH100 cheapest?" or "is g6e.12xlarge available in us-west-2?". Wraps the aoe-capacity scanner (public AWS APIs only).
+---
+
+# Find GPU Capacity
+
+When the user asks where GPUs are available or cheapest:
+
+1. Map the request to an EC2 instance type (8xH100 -> p5.48xlarge, L40S -> g6e.\*).
+2. `aoe-capacity find <instance_type> --regions all` (or a comma list of regions).
+3. Report the ranking cheapest-first (region, spot $/hr, on-demand $/hr, placement
+   score, availability) and name the single best option. Public AWS APIs only.

--- a/.kiro/skills/troubleshoot-inference/SKILL.md
+++ b/.kiro/skills/troubleshoot-inference/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: troubleshoot-inference
+description: Diagnose and fix a failing or degraded model deployment on EKS (CrashLoopBackOff, OOM, CUDA errors, Karpenter not scaling, HF token / gated repo errors). Use when a vLLM/Dynamo deployment on EKS is not healthy.
+---
+
+# Troubleshoot Inference on EKS
+
+When a deployment is failing or degraded:
+
+1. `kubectl get pods -l app=<name>`, `describe`, and `logs --tail=200`.
+2. Match the failure: Pending/no node -> Karpenter/capacity (check NodePool selector and
+   `aoe-capacity`); OOMKilled -> raise `--tensor-parallel-size` or lower `--max-model-len`;
+   CUDA driver mismatch -> align GPU AMI/device-plugin with image; 401 gated repo ->
+   recreate `hf-token` secret; unknown architecture -> pin a newer `container_image`.
+3. Re-apply and re-run the deploy verification curl. Report root cause and fix.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md — ai-on-eks
+
+Entry point for generic coding agents (Codex and others). This repo ships four agent
+capabilities for deploying open-weight models on EKS. The full instructions live in
+`.claude/skills/<skill>/SKILL.md` (Claude Code) and `.kiro/skills/<skill>/SKILL.md` (Kiro);
+this file is the provider-neutral summary.
+
+## Capabilities
+
+- **deploy-model** — "deploy qwen3-coder-30b": read `registry/models/<name>.yaml`,
+  `aoe-capacity find <instance_type>`, ensure the `hf-token` secret,
+  `aoe-blueprint gen ... | kubectl apply -f -`, then verify with a
+  `/v1/chat/completions` curl. Unregistered models get an unverified sizing estimate.
+- **find-capacity** — "where can I get 8xH100 cheapest?": run
+  `aoe-capacity find <instance_type> --regions all` and report the ranked list.
+- **benchmark-model** — concurrency sweep against a deployed endpoint; report
+  tokens_per_sec, ttft_ms, itl_ms, cost_per_1m_tok_usd.
+- **troubleshoot-inference** — diagnose OOM, CUDA mismatch, Karpenter scaling, and
+  gated-repo/HF-token failures.
+
+## Tools
+
+- `aoe-capacity` — `tools/capacity/` (public AWS APIs only).
+- `aoe-blueprint` — `tools/blueprintgen/` (registry entry -> Kubernetes manifest).
+- `python -m registry.validate` — validate registry entries.
+
+## Rules
+
+- Facts are verified-or-unset. Never invent benchmark numbers or a `tool_parser`.
+- Additive only: never restructure existing blueprints or Terraform.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ![AI on EKS](website/static/img/aioeks-logo-green.png)
+
 # [AI on Amazon EKS (AIoEKS)](https://awslabs.github.io/ai-on-eks/)
-*(Pronounced: "AI on EKS")*
+
+_(Pronounced: "AI on EKS")_
+
 > 💡 **Optimized Solutions for AI and ML on EKS**
 
 > ⚠️ **This repository is under active development as we support the new infrastructure format. Please raise any issues you may encounter**
@@ -16,6 +19,7 @@ Take advantage of high-performance [NVIDIA GPUs](https://aws.amazon.com/nvidia/)
 > **Note:** AIoEKS is in active development. For upcoming features and enhancements, check out the [issues](https://github.com/awslabs/ai-on-eks/issues) section.
 
 ## 🏃‍♀️Getting Started
+
 In this repository, you'll find a variety of deployment blueprints for creating AI/ML platforms with Amazon EKS clusters. These examples are just a small selection of the available blueprints - visit the [AIoEKS website](https://awslabs.github.io/ai-on-eks/) for the complete list of options.
 
 ### 🧠 AI
@@ -37,23 +41,40 @@ In this repository, you'll find a variety of deployment blueprints for creating 
 🚀 [Rate Limiting](blueprints/gateways/envoy-ai-gateway/rate-limiting/) 👈 Usage-based rate limiting with automatic tracking
 
 ## 📚 Documentation
+
 For instructions on how to deploy AI on EKS patterns and run sample tests, visit the [AIoEKS website](https://awslabs.github.io/ai-on-eks/).
 
 ## 🏆 Motivation
+
 [Kubernetes](https://kubernetes.io/) is a widely adopted system for orchestrating containerized software at scale. As more users migrate their AI and machine learning workloads to Kubernetes, they often face the complexity of managing the Kubernetes ecosystem and selecting the right tools and configurations for their specific needs.
 
 At [AWS](https://aws.amazon.com/), we understand the challenges users encounter when deploying and scaling AI/ML workloads on Kubernetes. To simplify the process and enable users to quickly conduct proof-of-concepts and build clusters, we have developed AI on EKS (AIoEKS). AIoEKS offers opinionated open-source blueprints that provide end-to-end logging and observability, making it easier for users to deploy and manage Ray, vLLM, Kubeflow, MLFlow, Jupyter and other AI/ML workloads. With AIoEKS, users can confidently leverage the power of Kubernetes for their AI and machine learning needs without getting overwhelmed by its complexity.
 
 ## 🤝 Support & Feedback
+
 AIoEKS is maintained by AWS Solution Architects and is not an AWS service. Support is provided on a best effort basis by the AI on EKS community. If you have feedback, feature ideas, or wish to report bugs, please use the [Issues](https://github.com/awslabs/ai-on-eks/issues) section of this GitHub.
 
 ## 🔐 Security
+
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
 
 ## 💼 License
+
 This library is licensed under the Apache 2.0 License.
 
 ## 🙌 Community
+
 We welcome all individuals who are enthusiastic about AI on Kubernetes to become a part of this open source community. Your contributions and participation are invaluable to the success of this project.
 
 Built with ❤️ at AWS.
+
+## Agent Skills
+
+This repo ships four agent skills for deploying open models on EKS —
+[`deploy-model`](.claude/skills/deploy-model/SKILL.md),
+[`find-capacity`](.claude/skills/find-capacity/SKILL.md),
+[`benchmark-model`](.claude/skills/benchmark-model/SKILL.md), and
+[`troubleshoot-inference`](.claude/skills/troubleshoot-inference/SKILL.md) — available to
+Claude Code (`.claude/skills/`), Kiro (`.kiro/skills/`), and generic agents
+([`AGENTS.md`](AGENTS.md)). Ask "deploy qwen3-coder-30b" and the skill reads the
+registry, checks capacity, generates a blueprint, applies it, and verifies the endpoint.


### PR DESCRIPTION
## What

Four agent skills for deploying open models on EKS, mirrored across `.claude/skills/` (Claude Code), `.kiro/skills/` (Kiro), and `AGENTS.md` (generic agents):

- **deploy-model** — resolve a registry entry, check capacity, ensure the `hf-token` secret, generate a blueprint, apply it, and verify the `/v1/chat/completions` endpoint.
- **find-capacity** — map a GPU request to an instance type and run the capacity scanner.
- **benchmark-model** — concurrency sweep against a deployed endpoint (tokens/sec, TTFT, ITL, cost).
- **troubleshoot-inference** — diagnose OOM, CUDA mismatch, Karpenter scaling, and gated-repo/HF-token failures.

They drive the `registry/`, `aoe-capacity`, and `aoe-blueprint` capabilities via natural-language requests.

## Scope / safety

Additive only; updates root README. No source behavior changes. Skills are documentation/instruction files — no executable code. Facts are verified-or-unset: the skills instruct agents never to invent benchmark numbers or a `tool_parser`.

## Note

The `.kiro/skills/<name>/SKILL.md` layout matches the repo's existing Kiro skills (`nodepools`, `argocd-addon`). These skills reference `aoe-capacity` / `aoe-blueprint`, which land in their own PRs.
