### PR TITLE
fix: move amiFamily label out of the restricted eks.amazonaws.com domain

### DIFF
--- a/.kiro/skills/nodepools/SKILL.md
+++ b/.kiro/skills/nodepools/SKILL.md
@@ -474,7 +474,7 @@ spec:
   template:
     metadata:
       labels:
-        ai.eks.amazonaws.com/amiFamily: ${ami_family}
+        ai-on-eks.io/amiFamily: ${ami_family}
         workload-type: training
     spec:
       expireAfter: 720h
@@ -527,7 +527,7 @@ spec:
   template:
     metadata:
       labels:
-        ai.eks.amazonaws.com/amiFamily: ${ami_family}
+        ai-on-eks.io/amiFamily: ${ami_family}
         workload-type: training
     spec:
       expireAfter: 720h

--- a/infra/base/terraform/helm-values/nvidia-device-plugin.yaml
+++ b/infra/base/terraform/helm-values/nvidia-device-plugin.yaml
@@ -3,7 +3,7 @@ mofedEnabled: false
 
 # Target only nodes running AL2023 AMIs
 nodeSelector:
-  ai.eks.amazonaws.com/amiFamily: al2023
+  ai-on-eks.io/amiFamily: al2023
 
 # Enable GPU Feature Discovery (default: false)
 gfd:
@@ -14,7 +14,7 @@ nfd:
   master:
     config:
       extraLabelNs:
-      - "ai.eks.amazonaws.com"
+      - "ai-on-eks.io"
       - "vpc.amazonaws.com"
       - "nvidia.com"
   worker:
@@ -27,7 +27,7 @@ nfd:
         custom:
           - name: "label amiFamily for al2023"
             labels:
-              "ai.eks.amazonaws.com/amiFamily": "al2023"
+              "ai-on-eks.io/amiFamily": "al2023"
             matchFeatures:
               - feature: system.osRelease
                 matchExpressions:
@@ -35,7 +35,7 @@ nfd:
                   VERSION_ID: {op: In, value: ["2023"]}
           - name: "label amiFamily for bottlerocket"
             labels:
-              "ai.eks.amazonaws.com/amiFamily": "bottlerocket"
+              "ai-on-eks.io/amiFamily": "bottlerocket"
             matchFeatures:
               - feature: system.osRelease
                 matchExpressions:

--- a/infra/base/terraform/helm-values/nvidia-gpu-operator.yaml
+++ b/infra/base/terraform/helm-values/nvidia-gpu-operator.yaml
@@ -6,7 +6,7 @@ node-feature-discovery:
   master:
     config:
       extraLabelNs:
-      - "ai.eks.amazonaws.com"
+      - "ai-on-eks.io"
       - "vpc.amazonaws.com"
       - "nvidia.com"
   worker:
@@ -19,7 +19,7 @@ node-feature-discovery:
         custom:
           - name: "label amiFamily for al2023"
             labels:
-              "ai.eks.amazonaws.com/amiFamily": "al2023"
+              "ai-on-eks.io/amiFamily": "al2023"
             matchFeatures:
               - feature: system.osRelease
                 matchExpressions:
@@ -27,7 +27,7 @@ node-feature-discovery:
                   VERSION_ID: {op: In, value: ["2023"]}
           - name: "label amiFamily bottlerocket"
             labels:
-              "ai.eks.amazonaws.com/amiFamily": "bottlerocket"
+              "ai-on-eks.io/amiFamily": "bottlerocket"
             matchFeatures:
               - feature: system.osRelease
                 matchExpressions:

--- a/infra/base/terraform/karpenter-resources/auto-mode/default.yaml
+++ b/infra/base/terraform/karpenter-resources/auto-mode/default.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       labels:
-        ai.eks.amazonaws.com/amiFamily: ${ami_family}
+        ai-on-eks.io/amiFamily: ${ami_family}
     spec:
       expireAfter: 336h
       nodeClassRef:

--- a/infra/base/terraform/karpenter-resources/auto-mode/gpu.yaml
+++ b/infra/base/terraform/karpenter-resources/auto-mode/gpu.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        ai.eks.amazonaws.com/amiFamily: ${ami_family}
+        ai-on-eks.io/amiFamily: ${ami_family}
         accelerator: nvidia
     spec:
       expireAfter: 336h

--- a/infra/base/terraform/karpenter-resources/auto-mode/neuron.yaml
+++ b/infra/base/terraform/karpenter-resources/auto-mode/neuron.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        ai.eks.amazonaws.com/amiFamily: ${ami_family}
+        ai-on-eks.io/amiFamily: ${ami_family}
         accelerator: neuron
     spec:
       expireAfter: 336h

--- a/infra/base/terraform/karpenter-resources/karpenter/default.yaml
+++ b/infra/base/terraform/karpenter-resources/karpenter/default.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        ai.eks.amazonaws.com/amiFamily: ${ami_family}
+        ai-on-eks.io/amiFamily: ${ami_family}
     spec:
       expireAfter: 720h
       nodeClassRef:

--- a/infra/base/terraform/karpenter-resources/karpenter/gpu-p-static.yaml
+++ b/infra/base/terraform/karpenter-resources/karpenter/gpu-p-static.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       labels:
-        ai.eks.amazonaws.com/amiFamily: ${ami_family}
+        ai-on-eks.io/amiFamily: ${ami_family}
         accelerator: nvidia
     spec:
       expireAfter: 720h

--- a/infra/base/terraform/karpenter-resources/karpenter/gpu-p.yaml
+++ b/infra/base/terraform/karpenter-resources/karpenter/gpu-p.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       labels:
-        ai.eks.amazonaws.com/amiFamily: ${ami_family}
+        ai-on-eks.io/amiFamily: ${ami_family}
         accelerator: nvidia
     spec:
       expireAfter: 720h

--- a/infra/base/terraform/karpenter-resources/karpenter/gpu.yaml
+++ b/infra/base/terraform/karpenter-resources/karpenter/gpu.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        ai.eks.amazonaws.com/amiFamily: ${ami_family}
+        ai-on-eks.io/amiFamily: ${ami_family}
         accelerator: nvidia
     spec:
       expireAfter: 720h

--- a/infra/base/terraform/karpenter-resources/karpenter/neuron.yaml
+++ b/infra/base/terraform/karpenter-resources/karpenter/neuron.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        ai.eks.amazonaws.com/amiFamily: ${ami_family}
+        ai-on-eks.io/amiFamily: ${ami_family}
         accelerator: neuron
     spec:
       expireAfter: 720h

--- a/infra/static-nodepool/nodepools/gpu-p5-48xlarge-static.yaml
+++ b/infra/static-nodepool/nodepools/gpu-p5-48xlarge-static.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       labels:
-        ai.eks.amazonaws.com/amiFamily: ${ami_family}
+        ai-on-eks.io/amiFamily: ${ami_family}
         accelerator: nvidia
     spec:
       expireAfter: Never

--- a/infra/static-nodepool/nodepools/gpu-p5en-48xlarge-static.yaml
+++ b/infra/static-nodepool/nodepools/gpu-p5en-48xlarge-static.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       labels:
-        ai.eks.amazonaws.com/amiFamily: al2023
+        ai-on-eks.io/amiFamily: al2023
         accelerator: nvidia
     spec:
       expireAfter: Never


### PR DESCRIPTION
## Problem

Every EKS Auto Mode install from current `main` fails at the default NodePools. Auto Mode's admission rejects NodePools carrying labels in the restricted `eks.amazonaws.com` domain:

```
NodePool.karpenter.sh "general-purpose" is invalid:
spec.template.metadata.labels: Invalid value: "object":
label domain "eks.amazonaws.com" is restricted
```

The `ai.eks.amazonaws.com/amiFamily` label (introduced in #324) falls under that domain. Found on a fresh `enable_eks_auto_mode = true` provision of `infra/agent-sandbox` (September 2026); reproduces for the base module's `general-purpose`, `gpu`, and `neuron` auto-mode NodePools, so it is independent of which solution is being installed.

## Blast radius

- **All 18 `infra/` sub-projects** consume the base module's auto-mode NodePool set via the copy-base pattern. None enable Auto Mode by default (`enable_eks_auto_mode` defaults to `false`), so standard installs are unaffected — but the Auto Mode path is broken for every sub-project.
- Standard-Karpenter installs are NOT broken (Karpenter does not restrict label domains) but carry the same label, and the in-repo consumers select on it.

## Fix

Rename `ai.eks.amazonaws.com/amiFamily` → `ai-on-eks.io/amiFamily` (project-owned domain) across every definition and consumer, atomically:

| Files | Role |
|---|---|
| `infra/base/terraform/karpenter-resources/auto-mode/{default,gpu,neuron}.yaml` | The failing NodePools |
| `infra/base/terraform/karpenter-resources/karpenter/{default,gpu,gpu-p,gpu-p-static,neuron}.yaml` | Standard-mode parity |
| `infra/base/terraform/helm-values/{nvidia-device-plugin,nvidia-gpu-operator}.yaml` | Node selectors consuming the label |
| `infra/static-nodepool/nodepools/gpu-p5{,en}-48xlarge-static.yaml` | Static P5 pools — must move with the nvidia selectors or GPU bootstrap silently breaks |
| `.kiro/skills/nodepools/SKILL.md` | NodePool authoring skill — prevents newly generated pools reintroducing the restricted domain |

**Deliberately untouched**: `ai.eks.amazonaws.com/name` in the kimi-k3 recipe README — a pod label written by the managed inference stack (service-owned), not defined by this repo.

## Naming — maintainer input requested

I propose `ai-on-eks.io` as the project-owned domain matching the repo identity. If you prefer a different domain, the change is merely mechanical and I will re-cut with the preferred naming convention. What won't work is leaving `eks.amazonaws.com` since Auto Mode admission makes that mandatory.

## Migration note for existing clusters

Existing nodes keep the old label until replaced; new nodes get the new label. In-repo consumers move atomically with this PR. Users with **custom** tooling selecting on `ai.eks.amazonaws.com/amiFamily` should update their selectors; during node turnover both labels exist in the fleet.

## Testing

- Fresh Auto Mode provision (`infra/agent-sandbox`, us-west-2) fails on unpatched main with the error above; succeeds with this change — all three default NodePools admitted, cluster fully functional through an end-to-end blueprint conformance run (5/5 outcomes).
- Standard EKS provision unaffected (validated same week on an unrelated branch).
- Repo-wide sweep confirms zero remaining `ai.eks.amazonaws.com` references outside the service-owned pod label noted above.

