### PR TITLE
feat: migrate agent-sandbox blueprint to agent-sandbox v1.0 (v1beta1 API)

### DIFF
--- a/blueprints/agent-sandbox/README.md
+++ b/blueprints/agent-sandbox/README.md
@@ -33,7 +33,7 @@ This blueprint exists for two reasons:
 | Subdirectory / file | Purpose |
 |---|---|
 | `agent.py` | The reference agent (Python) — five steps exercising FQDN + L3/L4 enforcement and gVisor's syscall boundary. |
-| `manifests/sandbox-agent.yaml` | The reference SandboxClaim + ServiceAccount + agent-script ConfigMap. The claim's `sandboxTemplateRef.name` is patched at apply time (`sandbox-agent-gvisor` on Standard EKS, `sandbox-agent-runc` on Auto Mode). |
+| `manifests/sandbox-agent.yaml` | The reference SandboxWarmPool + SandboxClaim + ServiceAccount + agent-script ConfigMap. The pool's `sandboxTemplateRef.name` is patched at apply time (`sandbox-agent-gvisor` on Standard EKS, `sandbox-agent-runc` on Auto Mode); the claim checks out from the pool (v1beta1 API). |
 | `manifests/sandbox-agent-runc.yaml` | Agent-shaped SandboxTemplate for the runc tier — adds `python:3.12-slim`, agent-script ConfigMap mount, Bedrock env vars, and `sandbox-agent-sa` IRSA-bound ServiceAccount on top of the `sandbox-runc` shape. |
 | `manifests/sandbox-agent-gvisor.yaml` | Same as `sandbox-agent-runc` with `runtimeClassName: gvisor` and the gVisor NodePool toleration. Standard EKS only. |
 | `manifests/kro/rgd.yaml` | KRO `ResourceGraphDefinition` exposing a single `AgentSandbox` CRD wrapping the same workload shape. Optional. |
@@ -69,7 +69,7 @@ The recommended path is `conformance.sh` — it auto-detects the cluster's compu
 
 ### Apply the SandboxClaim and reference agent
 
-The reference SandboxClaim (`manifests/sandbox-agent.yaml`) targets one of the agent-shaped SandboxTemplates that ship with this blueprint. Apply both templates first (one of them gets claimed depending on compute mode):
+The reference SandboxWarmPool + SandboxClaim (`manifests/sandbox-agent.yaml`) target one of the agent-shaped SandboxTemplates that ship with this blueprint — the pool references the template, the claim checks out from the pool. Apply both templates first (one of them gets claimed depending on compute mode):
 
 ```bash
 kubectl apply -f manifests/sandbox-agent-runc.yaml
@@ -77,7 +77,7 @@ kubectl apply -f manifests/sandbox-agent-runc.yaml
 kubectl apply -f manifests/sandbox-agent-gvisor.yaml
 ```
 
-The SandboxClaim carries a `__SANDBOX_TEMPLATE__` placeholder substituted at apply time. To apply by hand:
+The SandboxWarmPool carries a `__SANDBOX_TEMPLATE__` placeholder substituted at apply time. To apply by hand:
 
 ```bash
 SANDBOX_TEMPLATE=sandbox-agent-gvisor   # or sandbox-agent-runc for Auto Mode
@@ -189,7 +189,7 @@ For larger agents where a ConfigMap mount is impractical, bake `agent.py` into a
 |------|---------|
 | `agent.py` | The reference agent — 5 steps demonstrating FQDN + L3/L4 enforcement |
 | `conformance.sh` | Automated end-to-end test — applies the SandboxClaim, runs the agent, asserts PASS/BLOCKED markers |
-| `manifests/sandbox-agent.yaml` | SandboxClaim + ServiceAccount + agent-script ConfigMap |
+| `manifests/sandbox-agent.yaml` | SandboxWarmPool + SandboxClaim + ServiceAccount + agent-script ConfigMap |
 | `manifests/sandbox-agent-runc.yaml` | Agent-shaped SandboxTemplate for the runc tier |
 | `manifests/sandbox-agent-gvisor.yaml` | Agent-shaped SandboxTemplate for the gVisor tier |
 | `manifests/kro/{rgd,instance}.yaml` | KRO composition path — optional |

--- a/blueprints/agent-sandbox/basic/README.md
+++ b/blueprints/agent-sandbox/basic/README.md
@@ -4,7 +4,7 @@ The smallest viable Sandbox deployment, demonstrating sandboxing alone — no IR
 
 ## What ships
 
-- `sandbox-claim-basic.yaml` — a SandboxClaim that targets one of the basic SandboxTemplates installed by the platform infra.
+- `sandbox-claim-basic.yaml` — a SandboxWarmPool (replicas: 0, cold-start) that targets one of the basic SandboxTemplates installed by the platform infra, plus a SandboxClaim that checks out from the pool (v1beta1 API).
 - `install.sh` — auto-detects the cluster's compute mode (Standard EKS vs Auto Mode), substitutes the right SandboxTemplate name, applies the claim, waits for Ready, and (with `smoke`) runs a smoke test.
 - `README.md` — this file.
 
@@ -72,13 +72,13 @@ The basic templates (`sandbox-runc` for runc on both modes, `sandbox-gvisor` for
 - Pod labels `egress-tier: sandbox` + `agent-sandbox/tier: <runc|gvisor>` — these are matched by the egress example's network policies if you layer it on later
 - `runtimeClassName: gvisor` + matching `tolerations` (gvisor template only) — schedules onto the gVisor Karpenter NodePool
 
-The default workload image is `nginx:alpine` so the templates produce a Pod that runs out of the box. Swap it out by writing your own SandboxTemplate (copy the basic template, change the image, change the volumeMounts to fit your workload, give it a unique `metadata.name`) and pointing a SandboxClaim at it.
+The default workload image is `nginx:alpine` so the templates produce a Pod that runs out of the box. Swap it out by writing your own SandboxTemplate (copy the basic template, change the image, change the volumeMounts to fit your workload, give it a unique `metadata.name`), pointing a SandboxWarmPool at it, and pointing a SandboxClaim at the pool.
 
 ## Customizing the workload
 
 Two patterns:
 
-**(1) Write your own SandboxTemplate.** Copy [`sandbox-runc.yaml`](../../../infra/agent-sandbox/manifests/sandbox-runc.yaml) (or the gvisor variant) into your workload manifests, change `metadata.name`, change the container image + ports + volumeMounts, and apply it. Then point a SandboxClaim at the new template name. This is the canonical pattern — the basic templates demonstrate the shape.
+**(1) Write your own SandboxTemplate.** Copy [`sandbox-runc.yaml`](../../../infra/agent-sandbox/manifests/sandbox-runc.yaml) (or the gvisor variant) into your workload manifests, change `metadata.name`, change the container image + ports + volumeMounts, and apply it. Then point a SandboxWarmPool's `sandboxTemplateRef` at the new template name and a SandboxClaim's `warmPoolRef` at the pool. This is the canonical pattern — the basic templates demonstrate the shape.
 
 **(2) Use one of the agent-shaped templates.** If your workload happens to be a Python agent that wants the Bedrock + ConfigMap + IRSA scaffolding, the [reference agent's templates](../manifests/sandbox-agent-runc.yaml) are ready-made variants. They live in the blueprint, not the platform infra, because they bake in workload-specific assumptions.
 

--- a/blueprints/agent-sandbox/basic/install.sh
+++ b/blueprints/agent-sandbox/basic/install.sh
@@ -20,7 +20,7 @@
 #   cd blueprints/agent-sandbox/basic
 #   ./install.sh                # Mode detection + apply + wait for Ready
 #   ./install.sh smoke          # Apply + smoke test (kubectl exec into the pod)
-#   ./install.sh uninstall      # Remove the SandboxClaim
+#   ./install.sh uninstall      # Remove the SandboxWarmPool + SandboxClaim
 
 set -euo pipefail
 
@@ -91,13 +91,25 @@ apply_claim() {
         exit 1
     }
 
-    echo "=== Applying basic SandboxClaim ==="
+    echo "=== Applying basic SandboxWarmPool + SandboxClaim ==="
     sed "s|__SANDBOX_TEMPLATE__|$SANDBOX_TEMPLATE|g" \
         "$SCRIPT_DIR/sandbox-claim-basic.yaml" \
         | kubectl apply -f -
 
     echo "=== Waiting for Sandbox pod Ready (up to 3 min) ==="
-    # The pod's `metadata.name` is the same as the SandboxClaim's name.
+    # v1beta1 claims resolve through the warm pool (replicas: 0 →
+    # cold start), so the pod appears after pool + claim + sandbox
+    # reconciles. A cold-started sandbox takes the claim's name, and
+    # the pod's `metadata.name` always equals the sandbox's name —
+    # so pod/$CLAIM_NAME still holds. Poll for pod existence first;
+    # `kubectl wait` errors out immediately on a missing resource.
+    local attempt
+    for attempt in $(seq 1 12); do
+        if kubectl -n "$NS" get pod "$CLAIM_NAME" >/dev/null 2>&1; then
+            break
+        fi
+        sleep 5
+    done
     kubectl -n "$NS" wait --for=condition=Ready pod/"$CLAIM_NAME" --timeout=180s
 
     echo ""
@@ -134,7 +146,7 @@ smoke_test() {
 
 uninstall() {
     detect_compute_mode || true
-    echo "=== Removing basic SandboxClaim ==="
+    echo "=== Removing basic SandboxWarmPool + SandboxClaim ==="
     if [ -n "${SANDBOX_TEMPLATE:-}" ]; then
         sed "s|__SANDBOX_TEMPLATE__|$SANDBOX_TEMPLATE|g" \
             "$SCRIPT_DIR/sandbox-claim-basic.yaml" \
@@ -143,8 +155,9 @@ uninstall() {
         # Fall back to deleting by name+namespace if mode detection
         # failed (e.g., cluster already gone).
         kubectl -n "$NS" delete sandboxclaim "$CLAIM_NAME" --ignore-not-found
+        kubectl -n "$NS" delete sandboxwarmpool "${CLAIM_NAME}-pool" --ignore-not-found
     fi
-    echo "=== Basic SandboxClaim removed ==="
+    echo "=== Basic SandboxWarmPool + SandboxClaim removed ==="
 }
 
 case "$PHASE" in

--- a/blueprints/agent-sandbox/basic/sandbox-claim-basic.yaml
+++ b/blueprints/agent-sandbox/basic/sandbox-claim-basic.yaml
@@ -1,5 +1,6 @@
-# Basic SandboxClaim — points at one of the basic SandboxTemplates
-# (sandbox-runc or sandbox-gvisor) installed by the platform infra.
+# Basic SandboxWarmPool + SandboxClaim — points at one of the basic
+# SandboxTemplates (sandbox-runc or sandbox-gvisor) installed by the
+# platform infra.
 #
 # The smallest viable Sandbox: no IRSA, no agent script, no Bedrock env,
 # no FQDN allowlist. Default workload is the nginx:alpine image baked
@@ -7,11 +8,33 @@
 # as a working starting point — copy the manifest, swap in your own
 # SandboxTemplate, layer on egress / IRSA / ConfigMaps as needed.
 #
+# v1beta1 API shape (agent-sandbox v1.0+): a SandboxClaim no longer
+# references a SandboxTemplate directly. Claims check out from a
+# SandboxWarmPool, and the pool is what references the template. With
+# replicas: 0 the pool holds no pre-warmed sandboxes — each claim
+# cold-starts from the pool's template, which preserves the smallest-
+# viable cost profile of this blueprint. Bump replicas to pre-warm
+# sandboxes for near-instant claim binding.
+#
 # Template selection is deferred to apply time:
 #   - Standard EKS → sandboxTemplateRef.name = sandbox-gvisor
 #   - EKS Auto Mode → sandboxTemplateRef.name = sandbox-runc
 # install.sh renders the right value into __SANDBOX_TEMPLATE__.
-apiVersion: extensions.agents.x-k8s.io/v1alpha1
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxWarmPool
+metadata:
+  name: sandbox-basic-pool
+  namespace: agent-sandboxes
+  labels:
+    agent-sandbox/role: basic
+spec:
+  # No pre-warmed capacity — claims cold-start from the template.
+  replicas: 0
+  # Patched at apply time. See header comment for tier-selection rules.
+  sandboxTemplateRef:
+    name: __SANDBOX_TEMPLATE__
+---
+apiVersion: extensions.agents.x-k8s.io/v1beta1
 kind: SandboxClaim
 metadata:
   name: sandbox-basic
@@ -19,6 +42,5 @@ metadata:
   labels:
     agent-sandbox/role: basic
 spec:
-  # Patched at apply time. See header comment for tier-selection rules.
-  sandboxTemplateRef:
-    name: __SANDBOX_TEMPLATE__
+  warmPoolRef:
+    name: sandbox-basic-pool

--- a/blueprints/agent-sandbox/conformance.sh
+++ b/blueprints/agent-sandbox/conformance.sh
@@ -167,14 +167,18 @@ require_cluster() {
 }
 
 setup_configmap_with_real_agent() {
-    # sandbox-agent.yaml ships as a SandboxClaim with a templateRef
-    # placeholder and a placeholder ConfigMap. We:
+    # sandbox-agent.yaml ships as a SandboxWarmPool (replicas: 0, so
+    # claims cold-start from the template) + SandboxClaim, with a
+    # templateRef placeholder and a placeholder ConfigMap. We:
     #   1. Render the manifest with the resolved SandboxTemplate name
-    #      and apply it (creates SA + placeholder ConfigMap + Claim).
+    #      and apply it (creates SA + placeholder ConfigMap + Pool + Claim).
     #   2. Overwrite the ConfigMap with the real agent.py contents.
     #   3. Delete the controller-owned pod so it's recreated and the
     #      container's startup `cp /config/agent.py /workspace/agent.py`
     #      picks up the real content.
+    # A cold-started sandbox takes the claim's name, and the pod name
+    # always equals the sandbox name (v1.0 guarantee) — so the static
+    # POD=sandbox-agent reference below remains valid.
     RENDERED_SANDBOX_MANIFEST=$(mktemp -t agent-sandbox-claim.XXXXXX.yaml)
     sed -e "s|__SANDBOX_TEMPLATE__|$SANDBOX_TEMPLATE|g" \
         "$BLUEPRINT_MANIFEST_DIR/sandbox-agent.yaml" \
@@ -213,9 +217,18 @@ setup_irsa_annotation() {
 
 wait_for_pod() {
     log "Waiting for Sandbox pod Ready (up to 5 min)..."
-    # The controller recreates the pod after our delete; give it a
-    # moment to spawn a fresh one before waiting on Ready.
-    sleep 5
+    # The controller recreates the pod after our delete; the claim's
+    # cold-start path (pool → template → sandbox) may take a few
+    # reconciles before the pod object exists, and `kubectl wait`
+    # errors out immediately on a missing resource. Poll for existence
+    # first, then wait on Ready.
+    local attempt
+    for attempt in $(seq 1 12); do
+        if kubectl -n "$NS" get pod "$POD" >/dev/null 2>&1; then
+            break
+        fi
+        sleep 5
+    done
     if ! kubectl -n "$NS" wait --for=condition=Ready "pod/$POD" --timeout=300s >/dev/null; then
         kubectl -n "$NS" describe "pod/$POD" >&2
         fail "Sandbox pod did not become Ready within 5 min"

--- a/blueprints/agent-sandbox/manifests/kro/rgd.yaml
+++ b/blueprints/agent-sandbox/manifests/kro/rgd.yaml
@@ -81,7 +81,7 @@ spec:
       readyWhen:
         - ${sandbox.status.conditions.exists(x, x.type == "Ready" && x.status == "True")}
       template:
-        apiVersion: agents.x-k8s.io/v1alpha1
+        apiVersion: agents.x-k8s.io/v1beta1
         kind: Sandbox
         metadata:
           name: ${schema.metadata.name}

--- a/blueprints/agent-sandbox/manifests/sandbox-agent-gvisor.yaml
+++ b/blueprints/agent-sandbox/manifests/sandbox-agent-gvisor.yaml
@@ -16,7 +16,7 @@
 #     + a NodePool with the runsc containerd shim installed.
 #   - EKS Auto Mode: NO — Auto Mode workloads claim sandbox-agent-runc
 #     instead.
-apiVersion: extensions.agents.x-k8s.io/v1alpha1
+apiVersion: extensions.agents.x-k8s.io/v1beta1
 kind: SandboxTemplate
 metadata:
   name: sandbox-agent-gvisor

--- a/blueprints/agent-sandbox/manifests/sandbox-agent-runc.yaml
+++ b/blueprints/agent-sandbox/manifests/sandbox-agent-runc.yaml
@@ -18,7 +18,7 @@
 # Mode compatibility:
 #   - Standard EKS (Karpenter): yes
 #   - EKS Auto Mode: yes
-apiVersion: extensions.agents.x-k8s.io/v1alpha1
+apiVersion: extensions.agents.x-k8s.io/v1beta1
 kind: SandboxTemplate
 metadata:
   name: sandbox-agent-runc

--- a/blueprints/agent-sandbox/manifests/sandbox-agent.yaml
+++ b/blueprints/agent-sandbox/manifests/sandbox-agent.yaml
@@ -1,11 +1,19 @@
-# Reference SandboxClaim — per-instance binding that points at one
-# of the agent SandboxTemplates plus the per-deployment glue
-# (ServiceAccount + agent-script ConfigMap).
+# Reference SandboxWarmPool + SandboxClaim — per-instance binding that
+# points at one of the agent SandboxTemplates plus the per-deployment
+# glue (ServiceAccount + agent-script ConfigMap).
 #
 # The runtime spec (image, env, securityContext, volumes) lives in the
 # SandboxTemplate; the claim adds only deployment-specific bits — IRSA
-# wiring on the SA, the script ConfigMap the agent reads, and a pointer
-# to the chosen template.
+# wiring on the SA and the script ConfigMap the agent reads.
+#
+# v1beta1 API shape (agent-sandbox v1.0+): a SandboxClaim no longer
+# references a SandboxTemplate directly. Claims check out from a
+# SandboxWarmPool, and the pool is what references the template. With
+# replicas: 0 the pool holds no pre-warmed sandboxes — the claim
+# cold-starts from the pool's template, matching the pre-v1.0 behavior
+# of this blueprint (a cold-started sandbox also takes the claim's
+# name, so the pod is still `sandbox-agent`). Bump replicas to
+# pre-warm sandboxes for near-instant claim binding.
 #
 # Template selection is deferred to apply time:
 #   - Standard EKS → sandboxTemplateRef.name = sandbox-agent-gvisor
@@ -40,7 +48,24 @@ data:
   # This placeholder keeps the manifest self-contained for review.
   agent.py: "# populated by install.sh from blueprints/agent-sandbox/agent.py"
 ---
-apiVersion: extensions.agents.x-k8s.io/v1alpha1
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxWarmPool
+metadata:
+  name: sandbox-agent-pool
+  namespace: agent-sandboxes
+  labels:
+    agent-sandbox/role: runtime
+spec:
+  # No pre-warmed capacity — the claim cold-starts from the template,
+  # so the sandbox pod mounts the agent-script ConfigMap in its
+  # install-time state (conformance.sh replaces the placeholder content
+  # and recreates the pod, same flow as pre-v1.0).
+  replicas: 0
+  # Patched at apply time. See header comment for tier-selection rules.
+  sandboxTemplateRef:
+    name: __SANDBOX_TEMPLATE__
+---
+apiVersion: extensions.agents.x-k8s.io/v1beta1
 kind: SandboxClaim
 metadata:
   name: sandbox-agent
@@ -48,6 +73,5 @@ metadata:
   labels:
     agent-sandbox/role: runtime
 spec:
-  # Patched at apply time. See header comment for tier-selection rules.
-  sandboxTemplateRef:
-    name: __SANDBOX_TEMPLATE__
+  warmPoolRef:
+    name: sandbox-agent-pool

--- a/infra/agent-sandbox/README.md
+++ b/infra/agent-sandbox/README.md
@@ -42,7 +42,7 @@ flowchart TB
 
     A["Agent workload<br/>(Python agent, background processor, LLM-driven task runner)<br/>Runs inside a <b>Sandbox</b> (agents.x-k8s.io CRD)"]:::workload
 
-    B["SIG-Apps <b>agent-sandbox controller</b><br/>Manages Sandbox / SandboxTemplate / SandboxClaim lifecycle<br/><i>ArgoCD addon, enable_agent_sandbox=true</i>"]:::controller
+    B["SIG-Apps <b>agent-sandbox controller</b><br/>Manages Sandbox / SandboxTemplate / SandboxWarmPool / SandboxClaim lifecycle<br/><i>ArgoCD addon, enable_agent_sandbox=true</i>"]:::controller
 
     subgraph C["RuntimeClass selection"]
         direction LR
@@ -69,7 +69,7 @@ flowchart TB
 
 Two composition paths ship with the blueprint that layers on top of this infra:
 
-- **SandboxClaim** ([`blueprints/agent-sandbox/manifests/sandbox-agent.yaml`](../../blueprints/agent-sandbox/manifests/sandbox-agent.yaml)) — a thin claim that points at one of the SandboxTemplates plus the per-deployment glue (ServiceAccount + agent-script ConfigMap). The runtime spec lives in the template; the claim picks the tier. Native to the SIG-Apps Sandbox API.
+- **SandboxWarmPool + SandboxClaim** ([`blueprints/agent-sandbox/manifests/sandbox-agent.yaml`](../../blueprints/agent-sandbox/manifests/sandbox-agent.yaml)) — a pool that points at one of the SandboxTemplates, a thin claim that checks out from the pool, and the per-deployment glue (ServiceAccount + agent-script ConfigMap). The runtime spec lives in the template; the pool picks the tier. Native to the SIG-Apps Sandbox API (`v1beta1`).
 - **KRO AgentSandbox** ([`blueprints/agent-sandbox/manifests/kro/`](../../blueprints/agent-sandbox/manifests/kro/)) — the same workload composed via a single `AgentSandbox` custom resource. The `ResourceGraphDefinition` takes a `runtimeClass`, `iamRoleArn`, `scriptConfigMap`, and Bedrock region/model and materializes the SA + Sandbox in one declarative unit. Useful when exposing a simpler surface to your team.
 
 Both paths produce equivalent running pods. Each tier (`runc`, `gvisor`) is a SandboxTemplate the claim or AgentSandbox can target.
@@ -78,7 +78,7 @@ Both paths produce equivalent running pods. Each tier (`runc`, `gvisor`) is a Sa
 
 | Component | Version | Purpose |
 |-----------|---------|---------|
-| [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) | v0.4.5 | Sandbox / SandboxTemplate / SandboxClaim controller (base infra ArgoCD addon, `enable_agent_sandbox`) |
+| [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) | v1.0.1 | Sandbox / SandboxTemplate / SandboxWarmPool / SandboxClaim controller, `v1beta1` API (base infra ArgoCD addon, `enable_agent_sandbox`) |
 | [kro](https://kro.run/) | 0.9.1 | ResourceGraphDefinition-based composition (base infra ArgoCD addon, `enable_kro`; optional) |
 | [gVisor](https://gvisor.dev/) | runsc (AL2023) | Userspace syscall interception for gvisor tier (installed via Karpenter NodePool user-data) |
 | [Karpenter](https://karpenter.sh/) | Bundled with base module | Node autoscaling with a dedicated gVisor NodePool (Standard EKS) |
@@ -236,7 +236,7 @@ With the platform manifests applied, the cluster can host any SandboxClaim that 
 
 **Reference agent blueprint** ([`blueprints/agent-sandbox/`](../../blueprints/agent-sandbox/)) — complete agent workload with FQDN egress enforcement and end-to-end conformance:
 
-- **SandboxClaim + reference agent** ([`blueprints/agent-sandbox/manifests/sandbox-agent.yaml`](../../blueprints/agent-sandbox/manifests/sandbox-agent.yaml), [`agent.py`](../../blueprints/agent-sandbox/agent.py)) — the workload spec, agent script, and ServiceAccount glue. Claims the agent-shaped templates ([`sandbox-agent-runc.yaml`](../../blueprints/agent-sandbox/manifests/sandbox-agent-runc.yaml) / [`sandbox-agent-gvisor.yaml`](../../blueprints/agent-sandbox/manifests/sandbox-agent-gvisor.yaml)) which add the Python image + Bedrock env + ConfigMap mount on top of the basic templates' shape.
+- **SandboxWarmPool + SandboxClaim + reference agent** ([`blueprints/agent-sandbox/manifests/sandbox-agent.yaml`](../../blueprints/agent-sandbox/manifests/sandbox-agent.yaml), [`agent.py`](../../blueprints/agent-sandbox/agent.py)) — the workload spec, agent script, and ServiceAccount glue. The pool references the agent-shaped templates ([`sandbox-agent-runc.yaml`](../../blueprints/agent-sandbox/manifests/sandbox-agent-runc.yaml) / [`sandbox-agent-gvisor.yaml`](../../blueprints/agent-sandbox/manifests/sandbox-agent-gvisor.yaml)) which add the Python image + Bedrock env + ConfigMap mount on top of the basic templates' shape; the claim checks out from the pool.
 - **KRO composition path** ([`blueprints/agent-sandbox/manifests/kro/`](../../blueprints/agent-sandbox/manifests/kro/)) — same workload via a single `AgentSandbox` CR backed by a `ResourceGraphDefinition`.
 - **Egress enforcement example** ([`blueprints/agent-sandbox/egress/`](../../blueprints/agent-sandbox/egress/)) — auto-detects compute mode and applies Cilium CNPs (Standard EKS) or native ANPs (Auto Mode) plus the Bedrock IRSA role.
 - **Conformance test** ([`blueprints/agent-sandbox/conformance.sh`](../../blueprints/agent-sandbox/conformance.sh)) — claims the right agent template for the cluster's compute mode and exercises the full chain end-to-end.
@@ -274,7 +274,7 @@ See the [basic blueprint README](../../blueprints/agent-sandbox/basic/README.md)
 | `region` | AWS region | Base module default (`us-west-2`); uncomment to override |
 | `eks_cluster_version` | EKS version | `1.34` |
 | `enable_agent_sandbox` | Deploy the SIG-Apps agent-sandbox controller via ArgoCD | `true` |
-| `agent_sandbox_version` | kubernetes-sigs/agent-sandbox ref | `v0.4.5` |
+| `agent_sandbox_version` | kubernetes-sigs/agent-sandbox ref | `v1.0.1` |
 | `enable_kro` | Deploy kro via ArgoCD | `true` |
 | `kro_version` | kro Helm chart version | `0.9.1` |
 | `enable_cilium` | Deploy Cilium in aws-cni chaining mode (Standard EKS only — leave `false` for Auto Mode) | `true` |

--- a/infra/agent-sandbox/manifests/README.md
+++ b/infra/agent-sandbox/manifests/README.md
@@ -22,7 +22,7 @@ Each tier adds three files, parallel to the gVisor set:
 - `karpenter-nodepool-<tier>.yaml` — NodePool + EC2NodeClass with the tier's runtime shim install in user-data
 - `sandbox-<tier>.yaml` — SandboxTemplate using `runtimeClassName: <tier>` and the matching toleration
 
-A `SandboxClaim` (in any blueprint or your own workload) targets the new tier by setting `sandboxTemplateRef.name` accordingly. No changes elsewhere in this directory.
+A `SandboxWarmPool` (in any blueprint or your own workload) targets the new tier by setting `sandboxTemplateRef.name` accordingly; `SandboxClaim`s check out from the pool via `warmPoolRef.name` (v1beta1 API — claims no longer reference templates directly). No changes elsewhere in this directory.
 
 ## Layering on top
 

--- a/infra/agent-sandbox/manifests/sandbox-gvisor.yaml
+++ b/infra/agent-sandbox/manifests/sandbox-gvisor.yaml
@@ -18,7 +18,7 @@
 #   - blueprints/agent-sandbox/manifests/sandbox-agent-gvisor.yaml adds
 #     python:3.12-slim + agent-script ConfigMap mount + Bedrock env
 #     for the reference agent.
-apiVersion: extensions.agents.x-k8s.io/v1alpha1
+apiVersion: extensions.agents.x-k8s.io/v1beta1
 kind: SandboxTemplate
 metadata:
   name: sandbox-gvisor

--- a/infra/agent-sandbox/manifests/sandbox-runc.yaml
+++ b/infra/agent-sandbox/manifests/sandbox-runc.yaml
@@ -20,7 +20,7 @@
 #   - blueprints/agent-sandbox/manifests/sandbox-agent-runc.yaml adds
 #     python:3.12-slim + agent-script ConfigMap mount + Bedrock env
 #     for the reference agent.
-apiVersion: extensions.agents.x-k8s.io/v1alpha1
+apiVersion: extensions.agents.x-k8s.io/v1beta1
 kind: SandboxTemplate
 metadata:
   name: sandbox-runc

--- a/infra/base/terraform/variables.tf
+++ b/infra/base/terraform/variables.tf
@@ -398,7 +398,7 @@ variable "enable_agent_sandbox" {
 variable "agent_sandbox_version" {
   description = "kubernetes-sigs/agent-sandbox git ref (tag or branch) for the ArgoCD sync"
   type        = string
-  default     = "v0.4.5"
+  default     = "v1.0.1"
 }
 
 # Kube Resource Orchestrator (kro)

--- a/website/docs/infra/agents/agent-sandbox.md
+++ b/website/docs/infra/agents/agent-sandbox.md
@@ -34,7 +34,7 @@ flowchart TB
 
     A["Agent workload<br/>(Python agent, background processor, LLM-driven task runner)<br/>Runs inside a <b>Sandbox</b> (agents.x-k8s.io CRD)"]:::workload
 
-    B["SIG-Apps <b>agent-sandbox controller</b><br/>Manages Sandbox · SandboxTemplate · SandboxClaim lifecycle<br/><i>ArgoCD-managed addon (enable_agent_sandbox=true)</i>"]:::controller
+    B["SIG-Apps <b>agent-sandbox controller</b><br/>Manages Sandbox · SandboxTemplate · SandboxWarmPool · SandboxClaim lifecycle<br/><i>ArgoCD-managed addon (enable_agent_sandbox=true)</i>"]:::controller
 
     subgraph C["RuntimeClass selection"]
         direction LR
@@ -62,7 +62,7 @@ flowchart TB
 The solution deploys in layers:
 
 - **Amazon EKS cluster** with Karpenter for intelligent node autoscaling. A dedicated gVisor-capable NodePool provisions nodes with the `runsc` containerd shim installed via AL2023 user-data.
-- **kubernetes-sigs/agent-sandbox controller** (deployed as an ArgoCD-managed addon) manages `Sandbox`, `SandboxTemplate`, and `SandboxClaim` lifecycle.
+- **kubernetes-sigs/agent-sandbox controller** (deployed as an ArgoCD-managed addon) manages `Sandbox`, `SandboxTemplate`, `SandboxWarmPool`, and `SandboxClaim` lifecycle (`v1beta1` API, agent-sandbox v1.0+).
 - **KRO (Kube Resource Orchestrator)** (also ArgoCD-managed) composes multi-resource sandbox definitions behind a single `AgentSandbox` custom resource — useful when exposing a simpler surface to developer teams.
 - **Runtime tiers:** `standard` (runc, default Kubernetes runtime) and `gvisor` (runsc + Sentry userspace kernel).
 - **Egress enforcement** ships as a separate example to keep the sandbox runtime and egress concerns independently composable. Pair the infra with [agent-egress](https://github.com/awslabs/ai-on-eks/tree/main/blueprints/agent-sandbox/egress) — it auto-detects compute mode and applies Cilium + Hubble chaining (Standard EKS, requires `enable_cilium = true` in the base infra) or native VPC CNI `ApplicationNetworkPolicy` (EKS Auto Mode).
@@ -79,10 +79,10 @@ Each tier is a weaker boundary than the one below it — the choice maps to a th
 
 ### Two composition paths
 
-- **SandboxClaim** — a thin claim (`sandbox-agent.yaml`) that points at one of the SandboxTemplates plus the per-deployment glue (ServiceAccount + agent-script ConfigMap). The runtime spec lives in the template; the claim picks the tier. Native to the SIG-Apps Sandbox API.
+- **SandboxWarmPool + SandboxClaim** — a pool that points at one of the SandboxTemplates and a thin claim (`sandbox-agent.yaml`) that checks out from the pool, plus the per-deployment glue (ServiceAccount + agent-script ConfigMap). The runtime spec lives in the template; the pool picks the tier. Native to the SIG-Apps Sandbox API.
 - **KRO AgentSandbox** — the same workload composed via a single `AgentSandbox` custom resource (`kro/instance.yaml` + `kro/rgd.yaml`). The `ResourceGraphDefinition` takes a `runtimeClass`, `iamRoleArn`, `scriptConfigMap` reference, and Bedrock region/model, and materializes the SA + Sandbox in one declarative unit. Useful when exposing a simpler surface to your team.
 
-Both paths produce equivalent running pods. Each tier (`standard`, `gvisor`) is a SandboxTemplate the claim or AgentSandbox can target — the claim's `sandboxTemplateRef.name` (or the AgentSandbox's `runtimeClass`) selects which tier the pod runs on.
+Both paths produce equivalent running pods. Each tier (`standard`, `gvisor`) is a SandboxTemplate a SandboxWarmPool can target — the pool's `sandboxTemplateRef.name` (or the AgentSandbox's `runtimeClass`) selects which tier the pod runs on, and SandboxClaims check out from the pool via `warmPoolRef.name` (v1beta1 API, agent-sandbox v1.0+).
 
 ## Prerequisites
 
@@ -239,7 +239,7 @@ BEDROCK_ROLE_ARN=arn:aws:iam::<account>:role/agent-sandbox-bedrock-irsa \
 | `region` | AWS region | Base module default (`us-west-2`) |
 | `eks_cluster_version` | EKS version | `1.34` |
 | `enable_agent_sandbox` | Deploy the kubernetes-sigs agent-sandbox controller via ArgoCD | `true` |
-| `agent_sandbox_version` | kubernetes-sigs/agent-sandbox git ref | `v0.4.5` |
+| `agent_sandbox_version` | kubernetes-sigs/agent-sandbox git ref | `v1.0.1` |
 | `enable_kro` | Deploy kro via ArgoCD | `true` |
 | `kro_version` | kro Helm chart version | `0.9.1` |
 | `enable_eks_auto_mode` | Use EKS Auto Mode instead of Karpenter-managed compute | `false` |


### PR DESCRIPTION
> **Dependency note**: independent of #376 for Standard EKS. The Auto Mode validation below was run with #376's label fix applied (Auto Mode installs from main fail before this blueprint is reached). Recommend merging #376 first; no rebase needed either way — the diffs don't overlap.

## Why

Upstream `kubernetes-sigs/agent-sandbox` released **v1.0.0 (Aug 28) / v1.0.1**, removing the `v1alpha1` API entirely — all four CRDs now serve `v1beta1` only, and the conversion-webhook infrastructure is gone. The blueprint currently pins **v0.4.5** with `v1alpha1` manifests, which no longer install against the current upstream release. This migrates the solution to v1.0.1.

## What changed

**Version pin**
- `agent_sandbox_version` default `v0.4.5` → `v1.0.1`. Helm values unchanged (we set only `image.tag` + `controller.extensions`); ArgoCD renders the v1beta1-only CRDs on fresh installs.

**SandboxTemplates** (infra basic tiers + blueprint agent-shaped tiers)
- `apiVersion` bump to `extensions.agents.x-k8s.io/v1beta1` — schema unchanged upstream.

**SandboxClaims — the structural change**
- v1beta1 removed `spec.sandboxTemplateRef`; claims now check out from a `SandboxWarmPool` via required `spec.warmPoolRef`.
- Both blueprint claims (basic + reference agent) gain a **`replicas: 0` pool**: each claim cold-starts from the pool's template. This deliberately preserves the pre-v1.0 behavior and cost profile — no always-on warm capacity in a getting-started blueprint. The pool comment documents how to bump `replicas` for pre-warmed, near-instant claims.
- Cold-started sandboxes take the claim's name, and pod name == sandbox name is a v1.0 guarantee — so the well-known pod names (`sandbox-basic`, `sandbox-agent`) that the scripts and docs reference are stable (verified in the v1.0.1 claim controller: `createSandbox` sets `Name: claim.Name`).

**kro composition path**
- Core `Sandbox` in the RGD bumped to `agents.x-k8s.io/v1beta1`. The RGD sets neither `replicas` nor `operatingMode`, so the v1beta1 field rename there does not apply. kro's own `custom.agents.x-k8s.io/v1alpha1` schema group is kro versioning, not the sandbox API — unchanged.

**Scripts**
- `basic/install.sh` + `conformance.sh`: poll for pod existence before `kubectl wait` (the pool→claim→sandbox chain adds reconcile hops before the pod object exists; `kubectl wait` errors immediately on a missing resource).

**Docs**
- Claim→pool→template flow, v1.0.1 version tables, and CRD lists updated across the infra README, blueprint READMEs, manifests README, and the website page.

## Migration notes

- **Fresh installs** (the blueprint's path): no migration steps — `v1alpha1` is never stored.
- Existing clusters running the v0.4.5 blueprint should follow the upstream [v0.5.x](https://github.com/kubernetes-sigs/agent-sandbox/blob/v0.5.6/docs/api-migration-guide.md) → [v1.0.0](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/docs/api-migration-guide.md) migration guides (direct v0.4.x → v1.0.0 upgrades are unsupported upstream).

## Testing

Full matrix on fresh clusters (us-west-2, September 2026):

| Validation | Standard EKS | Auto Mode |
|---|---|---|
| Terraform provision + ArgoCD v1.0.1 sync, controller Available | ✅ | ✅ |
| All 4 CRDs `storedVersions == ["v1beta1"]` | ✅ | ✅ |
| Platform manifests apply (v1beta1 templates, RuntimeClass, NodePool) | ✅ | ✅ (runc only) |
| Basic blueprint `install.sh smoke` (pool + claim cold-start → nginx probe) | ✅ (gVisor tier) | ✅ (runc) |
| Egress example install (auto-detected mode) | ✅ Cilium | ✅ ANP |
| Full `conformance.sh` — PyPI PASS, Bedrock PASS, snippet PASS, FQDN BLOCKED, raw-IP BLOCKED | ✅ 5/5 | ✅ 5/5 |
| Cleanup to zero orphans | ✅ | ✅ |

## Reviewer notes

- The `replicas: 0` pool choice is intentional (cost/behavior parity for a reference blueprint). If maintainers prefer showcasing warm pools, I am happy to flip `replicas: 1` + `updateStrategy: Recreate` which matches the upstream quickstart behavior; conformance covers both since the claim path is identical.
- The webhook removal in v1.0 means fewer moving parts for the ArgoCD app: no cert secret, no conversion Service. Nothing to clean up on fresh installs.

